### PR TITLE
ci: add screenshot workflow for PWA

### DIFF
--- a/.github/workflows/screenshot.yml
+++ b/.github/workflows/screenshot.yml
@@ -9,6 +9,7 @@ on:
 permissions:
   contents: read
   pull-requests: write
+  issues: write
 
 jobs:
   screenshot:
@@ -16,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -26,7 +27,7 @@ jobs:
       - name: Install Playwright
         run: |
           npm init -y
-          npm install --save-dev @playwright/test
+          npm install --save-dev @playwright/test@1.50.1 http-server@14.1.1
           npx playwright install chromium
 
       - name: Start HTTP server


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/screenshot.yml` — Playwright-based CI triggered on every PR
- Captures **mobile** (390×844) and **desktop** (1920×1080) screenshots for all 3 PWA pages: shell launcher, Alert Kotwiczny, Wachtownik
- Wachtownik is captured in both **PL** and **EN** locales; attempts to click the Generate/Generuj button for post-interaction screenshots
- Screenshots uploaded as a 30-day artifact and embedded (base64 viewport thumbnails) in a PR comment — updates the comment on re-runs instead of creating duplicates
- Comment is skipped on forks where `GITHUB_TOKEN` is read-only

## How it works

1. Checks out code, installs Node 20 + Playwright Chromium
2. Serves `./pwa` via `http-server` on port 8080, polls until ready
3. Runs `take-screenshots.js` (inline Node script) — iterates viewports × pages × locales
4. Uploads artifact `screenshots/` (retention 30 days)
5. Posts/updates a comment on the PR with embedded viewport thumbnails + collapsible details