### PR TITLE
Raise PWA test coverage and address review feedback

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -426,7 +426,7 @@ jobs:
           fi
 
           echo "" >> coverage-comment.md
-          echo "_Coverage thresholds enforced: PWA ≥ 75% lines/statements/functions/branches (vitest), Android ≥ 90% lines (JaCoCo, after exclusions). Build fails if breached._" >> coverage-comment.md
+          echo "_Coverage thresholds enforced: PWA ≥ 90% lines/statements/functions/branches (Vitest), Android ≥ 90% lines (JaCoCo, after exclusions). Build fails if breached._" >> coverage-comment.md
 
       - name: Comment PR with coverage
         uses: marocchino/sticky-pull-request-comment@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -426,7 +426,7 @@ jobs:
           fi
 
           echo "" >> coverage-comment.md
-          echo "_Coverage thresholds enforced: PWA ≥ 90% lines/statements/functions/branches (Vitest), Android ≥ 90% lines (JaCoCo, after exclusions). Build fails if breached._" >> coverage-comment.md
+          echo "_Coverage policy: PWA ≥ 90% lines/statements/functions/branches is enforced by Vitest. Android ≥ 90% lines is currently reported as a warning by JaCoCo._" >> coverage-comment.md
 
       - name: Comment PR with coverage
         uses: marocchino/sticky-pull-request-comment@v3

--- a/pwa/e2e/anchor-lifecycle.spec.ts
+++ b/pwa/e2e/anchor-lifecycle.spec.ts
@@ -1,0 +1,58 @@
+import type { BrowserContext, Page } from '@playwright/test';
+import { test, expect } from './fixtures.js';
+import { MODULES } from './helpers.js';
+
+const START = { latitude: 54.5189, longitude: 18.5305, accuracy: 4 };
+
+async function gotoAnchor(page: Page, context: BrowserContext) {
+  await context.grantPermissions(['geolocation']);
+  await context.setGeolocation(START);
+  await page.goto(MODULES.anchor, { waitUntil: 'commit' });
+  await page.evaluate(() => localStorage.setItem('anchor_onboarding_done', 'true'));
+  await page.reload({ waitUntil: 'domcontentloaded' });
+  await expect(page.locator('#main-btn')).toBeEnabled({ timeout: 10_000 });
+}
+
+test.describe('Anchor — persisted session lifecycle', () => {
+  test('buffer-zone session persists, restores, replays, exports, and deletes', async ({
+    page,
+    context,
+  }) => {
+    test.slow();
+    await gotoAnchor(page, context);
+    await page.locator('#radius-number').fill('20');
+    await page.locator('#main-btn').click();
+
+    await context.setGeolocation({ ...START, latitude: START.latitude + 0.00021 });
+    await page.waitForTimeout(600);
+    await expect(page.locator('#alarm-state-bar')).toContainText(/uwaga|caution/i);
+
+    // Active state is restored from IndexedDB after a full application reload.
+    await page.reload({ waitUntil: 'domcontentloaded' });
+    await expect(page.locator('#main-btn-text')).not.toHaveText('Rzuć Kotwicę', {
+      timeout: 10_000,
+    });
+
+    await context.setGeolocation({ ...START, latitude: START.latitude + 0.00005 });
+    await page.locator('#main-btn').click();
+    await expect(page.locator('#main-btn-text')).toHaveText('Rzuć Kotwicę');
+
+    await page.locator('#open-history-btn').click();
+    const history = page.locator('#history-modal');
+    await expect(history).toBeVisible();
+    await expect(history.getByRole('button').filter({ hasText: /\d/ }).first()).toBeVisible();
+    await history.getByRole('button').filter({ hasText: /\d/ }).first().click();
+    await expect(page.locator('#replay-export-btn')).toBeVisible({ timeout: 15_000 });
+
+    const gpxDownload = page.waitForEvent('download');
+    await page.locator('#replay-export-btn').click();
+    await expect((await gpxDownload).suggestedFilename()).toMatch(/anchor-session-\d+\.gpx/);
+
+    const csvDownload = page.waitForEvent('download');
+    await history.getByRole('button', { name: /CSV/ }).click();
+    await expect((await csvDownload).suggestedFilename()).toMatch(/anchor-session-\d+\.csv/);
+
+    await history.getByRole('button', { name: /Usuń|Delete/ }).click();
+    await expect(history).toContainText(/Brak zapisanych sesji|No saved sessions/);
+  });
+});

--- a/pwa/e2e/anchor-lifecycle.spec.ts
+++ b/pwa/e2e/anchor-lifecycle.spec.ts
@@ -24,24 +24,23 @@ test.describe('Anchor — persisted session lifecycle', () => {
     await page.locator('#main-btn').click();
 
     await context.setGeolocation({ ...START, latitude: START.latitude + 0.00021 });
-    await page.waitForTimeout(600);
     await expect(page.locator('#alarm-state-bar')).toContainText(/uwaga|caution/i);
 
     // Active state is restored from IndexedDB after a full application reload.
     await page.reload({ waitUntil: 'domcontentloaded' });
-    await expect(page.locator('#main-btn-text')).not.toHaveText('Rzuć Kotwicę', {
+    await expect(page.locator('#main-btn-text')).toHaveText(/Podnieś Kotwicę|Raise Anchor/i, {
       timeout: 10_000,
     });
 
     await context.setGeolocation({ ...START, latitude: START.latitude + 0.00005 });
     await page.locator('#main-btn').click();
-    await expect(page.locator('#main-btn-text')).toHaveText('Rzuć Kotwicę');
+    await expect(page.locator('#main-btn-text')).toHaveText(/Rzuć Kotwicę|Drop Anchor/i);
 
     await page.locator('#open-history-btn').click();
     const history = page.locator('#history-modal');
     await expect(history).toBeVisible();
-    await expect(history.getByRole('button').filter({ hasText: /\d/ }).first()).toBeVisible();
-    await history.getByRole('button').filter({ hasText: /\d/ }).first().click();
+    await expect(history.getByTestId('session-history-item').first()).toBeVisible();
+    await history.getByTestId('session-history-item').first().click();
     await expect(page.locator('#replay-export-btn')).toBeVisible({ timeout: 15_000 });
 
     const gpxDownload = page.waitForEvent('download');

--- a/pwa/e2e/anchor.spec.ts
+++ b/pwa/e2e/anchor.spec.ts
@@ -834,9 +834,11 @@ test.describe('Anchor — Drag Warning Modal', () => {
 // 16. GPX Export Button
 // ---------------------------------------------------------------------------
 test.describe('Anchor — GPX Export', () => {
-  test('replay export button exists in DOM', async ({ page, mockGeolocation }) => {
+  test('export action is hidden until a replay is selected', async ({ page, mockGeolocation }) => {
     await mockGeolocation();
     await gotoAnchor(page);
-    await expect(page.locator('#replay-export-btn')).toBeAttached();
+    await page.locator('#open-history-btn').click();
+    await expect(page.locator('#history-modal')).toBeVisible();
+    await expect(page.locator('#replay-export-btn')).toHaveCount(0);
   });
 });

--- a/pwa/e2e/helpers.ts
+++ b/pwa/e2e/helpers.ts
@@ -7,6 +7,7 @@ export const MODULES = {
   anchor: '/modules/anchor/',
   egzamin: '/#/egzamin',
   wachtownik: '/#/wachtownik',
+  zeglowanie: '/#/zeglowanie',
 } as const;
 
 /** Common localStorage keys used across the app */
@@ -19,7 +20,7 @@ export const STORAGE_KEYS = {
 /** Mock geolocation coordinates */
 export const GEO = {
   gdyniaHarbor: { latitude: 54.5189, longitude: 18.5305 },
-  gdanskPort: { latitude: 54.3520, longitude: 18.6466 },
+  gdanskPort: { latitude: 54.352, longitude: 18.6466 },
 } as const;
 
 /** Polish UI strings used across anchor module tests */
@@ -31,7 +32,8 @@ export const ANCHOR_STRINGS = {
   behind: 'Z tyłu',
 } as const;
 
-const EGZAMIN_PLACEHOLDER_PNG = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==';
+const EGZAMIN_PLACEHOLDER_PNG =
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==';
 
 export async function installEgzaminPdfTestHook(page: Page): Promise<void> {
   await page.addInitScript(

--- a/pwa/e2e/zeglowanie.spec.ts
+++ b/pwa/e2e/zeglowanie.spec.ts
@@ -1,0 +1,143 @@
+import { test, expect } from './fixtures.js';
+import type { Page } from '@playwright/test';
+import { MODULES } from './helpers.js';
+
+const GOTO_OPTS = { waitUntil: 'networkidle' as const };
+
+async function openSection(page: Page, label: string) {
+  await page.getByRole('button', { name: label, exact: true }).click();
+}
+
+test.describe('Żeglowanie — complete user journeys', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(MODULES.zeglowanie, GOTO_OPTS);
+    await expect(page.getByRole('heading', { name: 'Informacje o Żeglarstwie' })).toBeVisible();
+  });
+
+  test('packing choices persist, switch cruise type, and reset', async ({ page }) => {
+    const firstItem = page.getByRole('checkbox').first();
+    await expect(firstItem).toHaveAttribute('aria-checked', 'false');
+    await firstItem.click();
+    await expect(firstItem).toHaveAttribute('aria-checked', 'true');
+
+    const storedPackingEntry = await page.evaluate(() =>
+      Object.entries(localStorage).find(
+        ([key, value]) => key.startsWith('sailing-baltic-autumn-') && value === 'true',
+      ),
+    );
+    expect(storedPackingEntry).toBeTruthy();
+
+    await page.reload(GOTO_OPTS);
+    await expect(page.getByRole('checkbox').first()).toHaveAttribute('aria-checked', 'true');
+
+    await page.getByRole('button', { name: /Chorwacja/ }).click();
+    await expect(page.getByRole('checkbox')).toHaveCount(24);
+    await expect
+      .poll(() => page.evaluate(() => localStorage.getItem('zeglowanie_selected_cruise_type')))
+      .toBe('croatia-summer');
+
+    page.once('dialog', (dialog) => dialog.accept());
+    await page.getByRole('button', { name: 'Wyczyść obecną listę' }).click();
+    await expect(page.getByRole('checkbox').first()).toHaveAttribute('aria-checked', 'false');
+  });
+
+  test('all navigation sections and briefing variants are usable and persisted', async ({
+    page,
+  }) => {
+    await openSection(page, 'Zakupy');
+    await expect(page.getByText('Lista Zakupów i Pomysły na Dania')).toBeVisible();
+
+    await openSection(page, 'Briefing');
+    await expect(page.getByText(/Briefing zerowy - Checklista/)).toBeVisible();
+    const firstBriefingItem = page.getByRole('checkbox').first();
+    await firstBriefingItem.press('Enter');
+    await expect(firstBriefingItem).toHaveAttribute('aria-checked', 'true');
+
+    await page.getByRole('button', { name: /Briefing pierwszy dzień/ }).click();
+    await expect(page.getByText(/Briefing pierwszy dzień - Checklista/)).toBeVisible();
+    await page.getByRole('checkbox').first().press(' ');
+    await expect(page.getByRole('checkbox').first()).toHaveAttribute('aria-checked', 'true');
+
+    await page.reload(GOTO_OPTS);
+    await expect(page.getByText(/Briefing pierwszy dzień - Checklista/)).toBeVisible();
+    await expect(page.getByRole('checkbox').first()).toHaveAttribute('aria-checked', 'true');
+
+    page.once('dialog', (dialog) => dialog.accept());
+    await page.getByRole('button', { name: 'Wyczyść checklistę' }).click();
+    await expect(page.getByRole('checkbox').first()).toHaveAttribute('aria-checked', 'false');
+  });
+
+  test('every operational checklist variant can be selected and reset', async ({ page }) => {
+    await openSection(page, 'Checklisty');
+
+    const variants = [
+      { name: /Codziennie rano/, count: 7 },
+      { name: /Wyjście z portu/, count: 13 },
+      { name: /Cumowanie/, count: 11 },
+      { name: /Grab bag/, count: 8 },
+    ];
+
+    for (const variant of variants) {
+      await page.getByRole('button', { name: variant.name }).click();
+      await expect(page.getByRole('checkbox')).toHaveCount(variant.count);
+      await page.getByRole('checkbox').first().click();
+      await expect(page.getByRole('checkbox').first()).toHaveAttribute('aria-checked', 'true');
+    }
+
+    page.once('dialog', (dialog) => dialog.dismiss());
+    await page.getByRole('button', { name: 'Wyczyść obecną checklistę' }).click();
+    await expect(page.getByRole('checkbox').first()).toHaveAttribute('aria-checked', 'true');
+
+    page.once('dialog', (dialog) => dialog.accept());
+    await page.getByRole('button', { name: 'Wyczyść obecną checklistę' }).click();
+    await expect(page.getByRole('checkbox').first()).toHaveAttribute('aria-checked', 'false');
+  });
+
+  test('VHF knowledge renders all operational channel groups', async ({ page }) => {
+    await openSection(page, 'Wiedza');
+    await page.getByRole('button', { name: /^📻 VHF/ }).click();
+
+    await expect(page.getByRole('heading', { name: /Kanały VHF/ })).toBeVisible();
+    await expect(page.getByText('Polish Rescue Radio')).toBeVisible();
+    await expect(page.getByText('VTS Zatoka')).toBeVisible();
+    await expect(page.getByText('anons 16, 71 · emisja 66')).toBeVisible();
+    await expect(page.getByText('Elbląg i wszystkie porty Zalewu Wiślanego')).toBeVisible();
+  });
+
+  test('ship-light viewer covers vessel families, night lights, and day marks', async ({
+    page,
+  }) => {
+    test.slow();
+    await openSection(page, 'Wiedza');
+    await expect(page.locator('canvas')).toBeVisible();
+    await expect(page.getByText('Prawidło 23(a)')).toBeVisible();
+
+    const representativeProfiles = [
+      /Motorowy ≥ 50m/,
+      /Żaglowy w drodze/,
+      /Trałowiec < 50m/,
+      /Holownik \(hol ≤ 200m\)/,
+      /Na kotwicy \(≥ 50m\)/,
+      /Niezdolny do manewru/,
+      /Ograniczona zdolność manewru/,
+      /Ograniczony zanurzeniem/,
+      /Trałowiec \(min\)/,
+      /Statek pilotowy/,
+      /Poduszkowiec/,
+      /Obiekt holowany \(hol > 200m\)/,
+    ];
+
+    for (const name of representativeProfiles) {
+      await page.getByRole('button', { name }).click();
+      await expect(page.locator('canvas')).toBeVisible();
+    }
+
+    await page.getByRole('button', { name: /Dzień|Noc/ }).click();
+    await expect(page.getByRole('button', { name: /Dzień/ })).toBeVisible();
+    await expect(page.getByText(/Kula|Stożek|Walec|Romb/).first()).toBeVisible();
+
+    await page.getByRole('button', { name: /Dzień/ }).click();
+    await expect(page.getByRole('button', { name: /Noc/ })).toBeVisible();
+    await expect(page.getByText(/Światło/).first()).toBeVisible();
+  });
+});

--- a/pwa/src/modules/anchor/App.tsx
+++ b/pwa/src/modules/anchor/App.tsx
@@ -405,7 +405,6 @@ function AnchorApp() {
         cog={state.cog}
         accuracy={state.accuracy}
         unit={state.unit === 'ft' ? 'feet' : 'meters'}
-        isAnchored={state.isAnchored}
       />
 
       <MapContainer

--- a/pwa/src/modules/anchor/components/Controls.tsx
+++ b/pwa/src/modules/anchor/components/Controls.tsx
@@ -242,7 +242,7 @@ export function Controls({
       {showMute && (
         <button
           onClick={onMuteAlarm}
-          className="anchor-tool-button w-full max-w-md mx-auto py-2.5 sm:py-3 rounded-xl text-sm sm:text-base font-bold transition-all active:scale-95 flex items-center justify-center gap-2 text-white mt-2 sm:mt-3"
+          className="anchor-tool-button anchor-tool-button--inverse w-full max-w-md mx-auto py-2.5 sm:py-3 rounded-xl text-sm sm:text-base font-bold transition-all active:scale-95 flex items-center justify-center gap-2 mt-2 sm:mt-3"
         >
           <BellOff className="w-4 sm:w-5 h-4 sm:h-5" />
           <span>{t.muteAlarm}</span>

--- a/pwa/src/modules/anchor/components/Dashboard.tsx
+++ b/pwa/src/modules/anchor/components/Dashboard.tsx
@@ -6,7 +6,6 @@ export interface DashboardProps {
   cog: number | null;
   accuracy: number;
   unit: string;
-  isAnchored: boolean;
 }
 
 const M_TO_FT = 3.28084;

--- a/pwa/src/modules/anchor/components/modals/SessionModal.tsx
+++ b/pwa/src/modules/anchor/components/modals/SessionModal.tsx
@@ -1,6 +1,5 @@
 import {
   History as HistoryIcon,
-  BarChart3,
   Download,
   FileSpreadsheet,
   Trash2,
@@ -62,6 +61,7 @@ export function SessionModal({
             return (
               <button
                 key={s.id}
+                data-testid="session-history-item"
                 onClick={() => s.id != null && onReplay(s.id)}
                 className="w-full text-left bg-slate-900 p-3 rounded-xl border border-slate-700 hover:border-blue-500 transition-colors"
               >
@@ -173,11 +173,6 @@ export function SessionModal({
   return (
     <Modal open={open} onClose={onClose} id="history-modal" className="flex flex-col max-h-[90vh]">
       {replaySession ? renderReplay() : renderSessionList()}
-
-      {/* Always attach export button for E2E discoverability */}
-      {!replaySession && (
-        <button id="replay-export-btn" className="hidden" aria-hidden="true" tabIndex={-1} />
-      )}
 
       <button
         onClick={onClose}

--- a/pwa/src/modules/anchor/hooks/useSessionHistory.ts
+++ b/pwa/src/modules/anchor/hooks/useSessionHistory.ts
@@ -35,6 +35,8 @@ export function useSessionHistory({
   isSessionModalOpen,
   isStatsModalOpen,
 }: UseSessionHistoryParams) {
+  const { getSessionHistory, getSessionReplay, deleteSession, getStats, db } = session;
+
   // ── Session history state ──
   const [sessions, setSessions] = useState<AnchorSession[]>([]);
   const [sessionsLoading, setSessionsLoading] = useState(false);
@@ -60,35 +62,35 @@ export function useSessionHistory({
     setSessionsLoading(true);
     setReplayData(null);
     try {
-      const list = await session.getSessionHistory();
+      const list = await getSessionHistory();
       setSessions(list);
     } catch {
       setSessions([]);
     }
     setSessionsLoading(false);
-  }, [session]);
+  }, [getSessionHistory]);
 
   const handleReplaySession = useCallback(
     async (sessionId: number) => {
-      const { session: s, points } = await session.getSessionReplay(sessionId);
+      const { session: s, points } = await getSessionReplay(sessionId);
       if (!s) return;
       let logEntries: LogbookEntry[] = [];
       try {
-        const db = session.db.current;
-        if (db?.db) {
-          logEntries = await db.db.getLogbookEntries(sessionId);
+        const database = db.current;
+        if (database?.db) {
+          logEntries = await database.db.getLogbookEntries(sessionId);
         }
       } catch {
         /* ignore */
       }
       setReplayData({ session: s, points, logEntries });
     },
-    [session],
+    [db, getSessionReplay],
   );
 
   const handleExportGPX = useCallback(
     async (sessionId: number) => {
-      const { session: s, points } = await session.getSessionReplay(sessionId);
+      const { session: s, points } = await getSessionReplay(sessionId);
       if (!s || points.length === 0) return;
 
       const gpxLines = [
@@ -111,12 +113,12 @@ export function useSessionHistory({
       a.click();
       URL.revokeObjectURL(url);
     },
-    [session],
+    [getSessionReplay],
   );
 
   const handleExportCSV = useCallback(
     async (sessionId: number) => {
-      const { points } = await session.getSessionReplay(sessionId);
+      const { points } = await getSessionReplay(sessionId);
       if (points.length === 0) return;
 
       const header = 'timestamp,lat,lng,accuracy,distance,alarmState';
@@ -133,25 +135,23 @@ export function useSessionHistory({
       a.click();
       URL.revokeObjectURL(url);
     },
-    [session],
+    [getSessionReplay],
   );
 
   const handleDeleteSession = useCallback(
     async (sessionId: number) => {
-      await session.deleteSession(sessionId);
+      await deleteSession(sessionId);
       setSessions((prev) => prev.filter((s) => s.id !== sessionId));
-      if (replayData?.session.id === sessionId) {
-        setReplayData(null);
-      }
+      setReplayData((current) => (current?.session.id === sessionId ? null : current));
     },
-    [session, replayData],
+    [deleteSession],
   );
 
   // ── Stats handler ──
 
   const loadStats = useCallback(async () => {
     try {
-      const s = await session.getStats();
+      const s = await getStats();
       setStatsData({
         totalSessions: s.totalSessions,
         totalAlarms: s.totalAlarms,
@@ -163,7 +163,7 @@ export function useSessionHistory({
     } catch {
       setStatsData(null);
     }
-  }, [session]);
+  }, [getStats]);
 
   // ── Auto-load effects ──
 

--- a/pwa/src/modules/anchor/styles.css
+++ b/pwa/src/modules/anchor/styles.css
@@ -181,7 +181,6 @@ input[type='range']::-webkit-slider-thumb {
 .anchor-tool-button {
   background: rgba(151, 190, 211, 0.08);
   border: 1px solid var(--oa-border);
-  border-color: var(--oa-border);
   color: #aebdc6;
 }
 
@@ -191,6 +190,10 @@ input[type='range']::-webkit-slider-thumb {
 
 .anchor-tool-button--accent {
   color: #67d5e8;
+}
+
+.anchor-tool-button--inverse {
+  color: #fff;
 }
 
 .anchor-primary-action {

--- a/pwa/styles/dashboard.css
+++ b/pwa/styles/dashboard.css
@@ -97,6 +97,7 @@
   border-radius: 1rem;
   background: rgba(13, 29, 44, 0.82);
   box-shadow: 0 16px 42px rgba(1, 10, 18, 0.18);
+  -webkit-backdrop-filter: blur(18px);
   backdrop-filter: blur(18px);
 }
 

--- a/pwa/tests/anchor-app-integration.test.tsx
+++ b/pwa/tests/anchor-app-integration.test.tsx
@@ -12,6 +12,7 @@ import React from 'react';
 import {
   installMockGeolocation,
   createMockGeolocation,
+  createMockPositionWithMotion,
 } from './mocks/geolocation';
 import { installMockWakeLock, installMockBattery } from './mocks/wake-lock';
 import { installMockAudioContext } from './mocks/web-audio';
@@ -226,9 +227,7 @@ describe('AnchorApp integration', () => {
     localStorage.setItem('anchor_onboarding_done', '1');
     await renderApp();
 
-    const beforeUnloadCalls = addSpy.mock.calls.filter(
-      ([event]) => event === 'beforeunload',
-    );
+    const beforeUnloadCalls = addSpy.mock.calls.filter(([event]) => event === 'beforeunload');
     expect(beforeUnloadCalls.length).toBeGreaterThanOrEqual(1);
     addSpy.mockRestore();
   });
@@ -263,5 +262,59 @@ describe('AnchorApp integration', () => {
     expect(container.querySelector('#val-dist')).toBeTruthy();
     expect(container.querySelector('#val-sog')).toBeTruthy();
     expect(container.querySelector('#val-cog')).toBeTruthy();
+  });
+
+  it('drives GPS, header controls, tools, sharing, and the anchor lifecycle', async () => {
+    localStorage.setItem('anchor_onboarding_done', '1');
+    (globalThis as any).AudioContext = function MockAudioContext() {
+      return audioMock.context;
+    };
+    const share = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'share', { value: share, configurable: true });
+    const { container } = await renderApp();
+
+    const onPosition = geo.watchPosition.mock.calls[0][0];
+    await act(async () => {
+      onPosition(createMockPositionWithMotion(52, 20, 4, 2.5, 180));
+    });
+    await waitFor(() =>
+      expect((container.querySelector('#main-btn') as HTMLButtonElement).disabled).toBe(false),
+    );
+
+    fireEvent.click(container.querySelector('#night-mode-btn')!);
+    expect(document.body.classList.contains('night-vision')).toBe(true);
+    fireEvent.click(container.querySelector('#unit-toggle')!);
+    fireEvent.click(container.querySelector('#lang-toggle')!);
+
+    fireEvent.change(container.querySelector('#radius-number')!, { target: { value: '75' } });
+    fireEvent.click(container.querySelector('#tool-calc')!);
+    expect(container.querySelector('#calc-modal')).toBeTruthy();
+    fireEvent.click(container.querySelector('#calc-modal .modal-close-btn')!);
+
+    fireEvent.click(container.querySelector('#share-pos-btn')!);
+    expect(share).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: 'OpenAnchor',
+        url: 'https://www.google.com/maps?q=52,20',
+      }),
+    );
+
+    await act(async () => {
+      fireEvent.click(container.querySelector('#main-btn')!);
+    });
+    await waitFor(() =>
+      expect(container.querySelector('#main-btn-text')?.textContent).toMatch(/Podnieś|Raise/),
+    );
+
+    await act(async () => {
+      onPosition(createMockPositionWithMotion(52.0001, 20.0001, 3, 3.5, 90));
+    });
+
+    await act(async () => {
+      fireEvent.click(container.querySelector('#main-btn')!);
+    });
+    await waitFor(() =>
+      expect(container.querySelector('#main-btn-text')?.textContent).toMatch(/Rzuć|Drop/),
+    );
   });
 });

--- a/pwa/tests/anchor-components.test.tsx
+++ b/pwa/tests/anchor-components.test.tsx
@@ -124,7 +124,10 @@ describe('Header', () => {
     expect(container.querySelector('.connection-status--offline')).toBeTruthy();
     expect(container.textContent).toContain('73% ⚡');
     expect(container.textContent).toContain('Eco');
-    expect(container.querySelector('#gps-status-text')?.className).toBeDefined();
+    expect(container.querySelector('#gps-status-text')?.textContent).toMatch(/Utrata|Lost/i);
+    expect(container.querySelector('#gps-status-text')?.parentElement?.className).toContain(
+      'text-red-500',
+    );
     fireEvent.click(container.querySelector('#unit-toggle')!);
     fireEvent.click(container.querySelector('#lang-toggle')!);
     expect(onToggleUnit).toHaveBeenCalledOnce();
@@ -171,7 +174,7 @@ describe('Dashboard', () => {
     const Dashboard = await importComponent();
     const { container } = render(<Dashboard {...baseProps} />, { wrapper: Wrapper });
     const unitLabels = container.querySelectorAll('.text-xs.text-slate-400');
-    const mLabels = Array.from(unitLabels).filter(el => el.textContent === 'm');
+    const mLabels = Array.from(unitLabels).filter((el) => el.textContent === 'm');
     expect(mLabels.length).toBeGreaterThanOrEqual(2);
   });
 
@@ -179,7 +182,7 @@ describe('Dashboard', () => {
     const Dashboard = await importComponent();
     const { container } = render(<Dashboard {...baseProps} unit="feet" />, { wrapper: Wrapper });
     const unitLabels = container.querySelectorAll('.text-xs.text-slate-400');
-    const ftLabels = Array.from(unitLabels).filter(el => el.textContent === 'ft');
+    const ftLabels = Array.from(unitLabels).filter((el) => el.textContent === 'ft');
     expect(ftLabels.length).toBeGreaterThanOrEqual(2);
   });
 
@@ -216,13 +219,17 @@ describe('AlarmBar', () => {
 
   it('returns null when not anchored', async () => {
     const AlarmBar = await importComponent();
-    const { container } = render(<AlarmBar {...baseProps} isAnchored={false} />, { wrapper: Wrapper });
+    const { container } = render(<AlarmBar {...baseProps} isAnchored={false} />, {
+      wrapper: Wrapper,
+    });
     expect(container.innerHTML).toBe('');
   });
 
   it('renders SAFE state with alarm-bar-safe class', async () => {
     const AlarmBar = await importComponent();
-    const { container } = render(<AlarmBar {...baseProps} alarmState="SAFE" />, { wrapper: Wrapper });
+    const { container } = render(<AlarmBar {...baseProps} alarmState="SAFE" />, {
+      wrapper: Wrapper,
+    });
     const bar = container.querySelector('#alarm-state-bar');
     expect(bar).toBeTruthy();
     expect(bar!.className).toContain('alarm-bar-safe');
@@ -231,7 +238,9 @@ describe('AlarmBar', () => {
 
   it('renders WARNING state with alarm-bar-warning class', async () => {
     const AlarmBar = await importComponent();
-    const { container } = render(<AlarmBar {...baseProps} alarmState="WARNING" />, { wrapper: Wrapper });
+    const { container } = render(<AlarmBar {...baseProps} alarmState="WARNING" />, {
+      wrapper: Wrapper,
+    });
     const bar = container.querySelector('#alarm-state-bar');
     expect(bar!.className).toContain('alarm-bar-warning');
   });
@@ -239,7 +248,9 @@ describe('AlarmBar', () => {
   it('renders ALARM state with mute button', async () => {
     const onDismiss = vi.fn();
     const AlarmBar = await importComponent();
-    render(<AlarmBar {...baseProps} alarmState="ALARM" onDismissAlarm={onDismiss} />, { wrapper: Wrapper });
+    render(<AlarmBar {...baseProps} alarmState="ALARM" onDismissAlarm={onDismiss} />, {
+      wrapper: Wrapper,
+    });
 
     const muteBtn = screen.getByRole('button', { name: /Wycisz|Mute/i });
     expect(muteBtn).toBeTruthy();
@@ -336,7 +347,9 @@ describe('SimpleMonitor', () => {
 
   it('returns null when not visible', async () => {
     const SimpleMonitor = await importComponent();
-    const { container } = render(<SimpleMonitor {...baseProps} visible={false} />, { wrapper: Wrapper });
+    const { container } = render(<SimpleMonitor {...baseProps} visible={false} />, {
+      wrapper: Wrapper,
+    });
     expect(container.innerHTML).toBe('');
   });
 
@@ -356,7 +369,9 @@ describe('SimpleMonitor', () => {
   it('shows mute button in ALARM state', async () => {
     const onDismiss = vi.fn();
     const SimpleMonitor = await importComponent();
-    render(<SimpleMonitor {...baseProps} alarmState="ALARM" onDismissAlarm={onDismiss} />, { wrapper: Wrapper });
+    render(<SimpleMonitor {...baseProps} alarmState="ALARM" onDismissAlarm={onDismiss} />, {
+      wrapper: Wrapper,
+    });
     const muteBtn = screen.getByText(/Wycisz|Mute/i);
     expect(muteBtn).toBeTruthy();
   });
@@ -385,21 +400,18 @@ describe('SimpleMonitor', () => {
     expect(container.querySelector('.simple-monitor-bg-warning')).toBeTruthy();
     fireEvent.click(screen.getByText(/Wycisz|Mute/i));
     fireEvent.click(container.querySelector('#sm-close-btn')!);
-    fireEvent.click(Array.from(container.querySelectorAll('button')).find((button) =>
-      button.querySelector('[data-icon="Moon"]'),
-    )!);
+    fireEvent.click(
+      Array.from(container.querySelectorAll('button')).find((button) =>
+        button.querySelector('[data-icon="Moon"]'),
+      )!,
+    );
     expect(onDismissAlarm).toHaveBeenCalledOnce();
     expect(onOpenMap).toHaveBeenCalledOnce();
     expect(onToggleNightRed).toHaveBeenCalledOnce();
 
     rerender(
       <Wrapper>
-        <SimpleMonitor
-          {...baseProps}
-          alarmState="UNKNOWN"
-          hasGpsFix={true}
-          gpsSignalLost={true}
-        />
+        <SimpleMonitor {...baseProps} alarmState="UNKNOWN" hasGpsFix={true} gpsSignalLost={true} />
       </Wrapper>,
     );
     expect(container.querySelector('.simple-monitor-bg-safe')).toBeTruthy();
@@ -417,7 +429,9 @@ describe('Onboarding', () => {
 
   it('returns null when not visible', async () => {
     const Onboarding = await importComponent();
-    const { container } = render(<Onboarding visible={false} onComplete={vi.fn()} />, { wrapper: Wrapper });
+    const { container } = render(<Onboarding visible={false} onComplete={vi.fn()} />, {
+      wrapper: Wrapper,
+    });
     expect(container.innerHTML).toBe('');
   });
 
@@ -457,7 +471,9 @@ describe('MapContainer', () => {
   it('renders map div with correct id', async () => {
     const ref = React.createRef<HTMLDivElement>();
     const MapContainer = await importComponent();
-    render(<MapContainer mapRef={ref} hasGpsFix={true} gpsSignalLost={false} />, { wrapper: Wrapper });
+    render(<MapContainer mapRef={ref} hasGpsFix={true} gpsSignalLost={false} />, {
+      wrapper: Wrapper,
+    });
     const mapDiv = document.getElementById('map');
     expect(mapDiv).toBeTruthy();
     expect(mapDiv!.getAttribute('role')).toBe('application');
@@ -466,7 +482,9 @@ describe('MapContainer', () => {
   it('passes ref to the map div', async () => {
     const ref = React.createRef<HTMLDivElement>();
     const MapContainer = await importComponent();
-    render(<MapContainer mapRef={ref} hasGpsFix={true} gpsSignalLost={false} />, { wrapper: Wrapper });
+    render(<MapContainer mapRef={ref} hasGpsFix={true} gpsSignalLost={false} />, {
+      wrapper: Wrapper,
+    });
     expect(ref.current).toBeTruthy();
     expect(ref.current!.id).toBe('map');
   });
@@ -474,7 +492,9 @@ describe('MapContainer', () => {
   it('shows no-signal overlay when GPS fix is missing', async () => {
     const ref = React.createRef<HTMLDivElement>();
     const MapContainer = await importComponent();
-    render(<MapContainer mapRef={ref} hasGpsFix={false} gpsSignalLost={false} />, { wrapper: Wrapper });
+    render(<MapContainer mapRef={ref} hasGpsFix={false} gpsSignalLost={false} />, {
+      wrapper: Wrapper,
+    });
     expect(screen.getByText(/Brak sygnału GPS|No GPS signal/)).toBeTruthy();
   });
 });

--- a/pwa/tests/anchor-components.test.tsx
+++ b/pwa/tests/anchor-components.test.tsx
@@ -100,6 +100,44 @@ describe('Header', () => {
     render(<Header {...baseProps} unit="meters" />, { wrapper: Wrapper });
     expect(screen.getByText(/METRY|METERS/)).toBeTruthy();
   });
+
+  it('renders offline, lost-GPS, peer, charging, eco, feet, and connected states', async () => {
+    const Header = await importComponent();
+    const onToggleUnit = vi.fn();
+    const onToggleLang = vi.fn();
+    const { container, rerender } = render(
+      <Header
+        {...baseProps}
+        isOnline={false}
+        unit="feet"
+        wsConnected={true}
+        peerBattery={73}
+        peerCharging={true}
+        hasGpsFix={true}
+        gpsSignalLost={true}
+        batterySaverActive={true}
+        onToggleUnit={onToggleUnit}
+        onToggleLang={onToggleLang}
+      />,
+      { wrapper: Wrapper },
+    );
+    expect(container.querySelector('.connection-status--offline')).toBeTruthy();
+    expect(container.textContent).toContain('73% ⚡');
+    expect(container.textContent).toContain('Eco');
+    expect(container.querySelector('#gps-status-text')?.className).toBeDefined();
+    fireEvent.click(container.querySelector('#unit-toggle')!);
+    fireEvent.click(container.querySelector('#lang-toggle')!);
+    expect(onToggleUnit).toHaveBeenCalledOnce();
+    expect(onToggleLang).toHaveBeenCalledOnce();
+
+    rerender(
+      <Wrapper>
+        <Header {...baseProps} peerBattery={42} peerCharging={false} />
+      </Wrapper>,
+    );
+    expect(container.textContent).toContain('42%');
+    expect(container.textContent).not.toContain('42% ⚡');
+  });
 });
 
 // ── Dashboard ────────────────────────────────────────────────────────
@@ -321,6 +359,51 @@ describe('SimpleMonitor', () => {
     render(<SimpleMonitor {...baseProps} alarmState="ALARM" onDismissAlarm={onDismiss} />, { wrapper: Wrapper });
     const muteBtn = screen.getByText(/Wycisz|Mute/i);
     expect(muteBtn).toBeTruthy();
+  });
+
+  it('covers warning, feet, missing GPS/COG, night filter, fallback state, and actions', async () => {
+    const SimpleMonitor = await importComponent();
+    const onDismissAlarm = vi.fn();
+    const onToggleNightRed = vi.fn();
+    const onOpenMap = vi.fn();
+    const { container, rerender } = render(
+      <SimpleMonitor
+        {...baseProps}
+        unit="feet"
+        alarmState="WARNING"
+        hasGpsFix={false}
+        cog={null}
+        nightRedFilter={true}
+        onDismissAlarm={onDismissAlarm}
+        onToggleNightRed={onToggleNightRed}
+        onOpenMap={onOpenMap}
+      />,
+      { wrapper: Wrapper },
+    );
+    expect(container.textContent).toContain('---');
+    expect(container.textContent).toContain('ft');
+    expect(container.querySelector('.simple-monitor-bg-warning')).toBeTruthy();
+    fireEvent.click(screen.getByText(/Wycisz|Mute/i));
+    fireEvent.click(container.querySelector('#sm-close-btn')!);
+    fireEvent.click(Array.from(container.querySelectorAll('button')).find((button) =>
+      button.querySelector('[data-icon="Moon"]'),
+    )!);
+    expect(onDismissAlarm).toHaveBeenCalledOnce();
+    expect(onOpenMap).toHaveBeenCalledOnce();
+    expect(onToggleNightRed).toHaveBeenCalledOnce();
+
+    rerender(
+      <Wrapper>
+        <SimpleMonitor
+          {...baseProps}
+          alarmState="UNKNOWN"
+          hasGpsFix={true}
+          gpsSignalLost={true}
+        />
+      </Wrapper>,
+    );
+    expect(container.querySelector('.simple-monitor-bg-safe')).toBeTruthy();
+    expect(container.textContent).toContain('UNKNOWN');
   });
 });
 

--- a/pwa/tests/anchor-coverage-extra.test.tsx
+++ b/pwa/tests/anchor-coverage-extra.test.tsx
@@ -1050,7 +1050,7 @@ describe('SessionModal — branch coverage', () => {
     expect(onClose).toHaveBeenCalled();
   });
 
-  it('shows hidden export button when no replay session', async () => {
+  it('does not render export actions when no replay session is selected', async () => {
     const SessionModal = await importSessionModal();
 
     const { container } = render(
@@ -1068,7 +1068,6 @@ describe('SessionModal — branch coverage', () => {
       />,
     );
 
-    const hiddenBtn = container.querySelector('#replay-export-btn');
-    expect(hiddenBtn).not.toBeNull();
+    expect(container.querySelector('#replay-export-btn')).toBeNull();
   });
 });

--- a/pwa/tests/anchor-modals.test.tsx
+++ b/pwa/tests/anchor-modals.test.tsx
@@ -50,9 +50,7 @@ function Wrapper({ children }: { children: React.ReactNode }) {
 
 describe('Modal (base)', () => {
   async function importComponent() {
-    const { Modal } = await import(
-      '../src/modules/anchor/components/modals/Modal'
-    );
+    const { Modal } = await import('../src/modules/anchor/components/modals/Modal');
     return Modal;
   }
 
@@ -104,9 +102,7 @@ describe('Modal (base)', () => {
 
 describe('CalcModal', () => {
   async function importComponent() {
-    const { CalcModal } = await import(
-      '../src/modules/anchor/components/modals/CalcModal'
-    );
+    const { CalcModal } = await import('../src/modules/anchor/components/modals/CalcModal');
     return CalcModal;
   }
 
@@ -123,7 +119,9 @@ describe('CalcModal', () => {
   it('renders input fields for depth and ratio selector', async () => {
     const CalcModal = await importComponent();
     const { container } = render(
-      <Wrapper><CalcModal {...defaultProps} /></Wrapper>,
+      <Wrapper>
+        <CalcModal {...defaultProps} />
+      </Wrapper>,
     );
     expect(container.querySelector('#calc-depth')).toBeTruthy();
     expect(container.querySelector('#calc-ratio')).toBeTruthy();
@@ -132,7 +130,9 @@ describe('CalcModal', () => {
   it('computes swing radius using sqrt(chain²-depth²) × 1.2', async () => {
     const CalcModal = await importComponent();
     const { container } = render(
-      <Wrapper><CalcModal {...defaultProps} /></Wrapper>,
+      <Wrapper>
+        <CalcModal {...defaultProps} />
+      </Wrapper>,
     );
     // Default: depth=5, ratio=5 → chain=25
     // swing = sqrt(25²-5²) = sqrt(600) ≈ 24.49, radius = round(24.49 * 1.2) = 29
@@ -170,9 +170,7 @@ describe('CalcModal', () => {
 
 describe('SessionModal', () => {
   async function importComponent() {
-    const { SessionModal } = await import(
-      '../src/modules/anchor/components/modals/SessionModal'
-    );
+    const { SessionModal } = await import('../src/modules/anchor/components/modals/SessionModal');
     return SessionModal;
   }
 
@@ -216,10 +214,7 @@ describe('SessionModal', () => {
         <SessionModal {...defaultProps} sessions={sessions} />
       </Wrapper>,
     );
-    // Each session renders as a button
-    const buttons = screen.getAllByRole('button');
-    // Should have session buttons + close button + hidden export button
-    expect(buttons.length).toBeGreaterThanOrEqual(3);
+    expect(screen.getAllByTestId('session-history-item')).toHaveLength(2);
   });
 
   it('duration uses formatDuration with ms (not seconds)', async () => {
@@ -259,9 +254,7 @@ describe('SessionModal', () => {
 
 describe('StatsModal', () => {
   async function importComponent() {
-    const { StatsModal } = await import(
-      '../src/modules/anchor/components/modals/StatsModal'
-    );
+    const { StatsModal } = await import('../src/modules/anchor/components/modals/StatsModal');
     return StatsModal;
   }
 
@@ -269,7 +262,7 @@ describe('StatsModal', () => {
     totalSessions: 10,
     totalAlarms: 2,
     totalTime: 7200000, // 2h in ms
-    avgTime: 3600000,   // 1h in ms
+    avgTime: 3600000, // 1h in ms
     maxDistance: 25.3,
     maxSog: 1.7,
   };
@@ -304,9 +297,7 @@ describe('StatsModal', () => {
 
 describe('WatchModal', () => {
   async function importComponent() {
-    const { WatchModal } = await import(
-      '../src/modules/anchor/components/modals/WatchModal'
-    );
+    const { WatchModal } = await import('../src/modules/anchor/components/modals/WatchModal');
     return WatchModal;
   }
 
@@ -330,7 +321,9 @@ describe('WatchModal', () => {
       { start: '12:00', end: '16:00', person: 'Bob' },
     ];
     const { container } = render(
-      <Wrapper><WatchModal {...defaultProps} schedule={schedule} /></Wrapper>,
+      <Wrapper>
+        <WatchModal {...defaultProps} schedule={schedule} />
+      </Wrapper>,
     );
     expect(container.textContent).toContain('Alice');
     expect(container.textContent).toContain('Bob');
@@ -356,7 +349,7 @@ describe('WatchModal', () => {
 
     // Click add button
     const addBtns = Array.from(container.querySelectorAll('button'));
-    const addBtn = addBtns.find(b => b.textContent?.includes('Dodaj'))!;
+    const addBtn = addBtns.find((b) => b.textContent?.includes('Dodaj'))!;
     fireEvent.click(addBtn);
 
     expect(onAddScheduleItem).toHaveBeenCalledWith({
@@ -389,9 +382,7 @@ describe('WatchModal', () => {
 
 describe('SyncModal', () => {
   async function importComponent() {
-    const { SyncModal } = await import(
-      '../src/modules/anchor/components/modals/SyncModal'
-    );
+    const { SyncModal } = await import('../src/modules/anchor/components/modals/SyncModal');
     return SyncModal;
   }
 
@@ -408,7 +399,9 @@ describe('SyncModal', () => {
   it('renders URL input field with value', async () => {
     const SyncModal = await importComponent();
     const { container } = render(
-      <Wrapper><SyncModal {...defaultProps} /></Wrapper>,
+      <Wrapper>
+        <SyncModal {...defaultProps} />
+      </Wrapper>,
     );
     const input = container.querySelector('input[type="text"]') as HTMLInputElement;
     expect(input).toBeTruthy();
@@ -423,15 +416,13 @@ describe('SyncModal', () => {
     // Test connect when disconnected
     const { unmount } = render(
       <Wrapper>
-        <SyncModal
-          {...defaultProps}
-          onConnect={onConnect}
-          onDisconnect={onDisconnect}
-        />
+        <SyncModal {...defaultProps} onConnect={onConnect} onDisconnect={onDisconnect} />
       </Wrapper>,
     );
     const buttons = Array.from(document.querySelectorAll('button'));
-    const connectBtn = buttons.find(b => b.textContent?.includes('Połącz') || b.textContent?.includes('Connect'));
+    const connectBtn = buttons.find(
+      (b) => b.textContent?.includes('Połącz') || b.textContent?.includes('Connect'),
+    );
     fireEvent.click(connectBtn!);
     expect(onConnect).toHaveBeenCalledWith('ws://192.168.1.1:8080');
     unmount();
@@ -448,7 +439,11 @@ describe('SyncModal', () => {
       </Wrapper>,
     );
     const buttons2 = Array.from(document.querySelectorAll('button'));
-    const disconnectBtn = buttons2.find(b => !b.disabled && (b.textContent?.includes('Rozłącz') || b.textContent?.includes('Disconnect')));
+    const disconnectBtn = buttons2.find(
+      (b) =>
+        !b.disabled &&
+        (b.textContent?.includes('Rozłącz') || b.textContent?.includes('Disconnect')),
+    );
     fireEvent.click(disconnectBtn!);
     expect(onDisconnect).toHaveBeenCalled();
   });
@@ -458,9 +453,7 @@ describe('SyncModal', () => {
 
 describe('WeatherModal', () => {
   async function importComponent() {
-    const { WeatherModal } = await import(
-      '../src/modules/anchor/components/modals/WeatherModal'
-    );
+    const { WeatherModal } = await import('../src/modules/anchor/components/modals/WeatherModal');
     return WeatherModal;
   }
 
@@ -506,7 +499,9 @@ describe('WeatherModal', () => {
   it('shows loading state', async () => {
     const WeatherModal = await importComponent();
     const { container } = render(
-      <Wrapper><WeatherModal {...defaultProps} loading={true} /></Wrapper>,
+      <Wrapper>
+        <WeatherModal {...defaultProps} loading={true} />
+      </Wrapper>,
     );
     // Loading spinner icon should be present
     expect(container.querySelector('[data-icon="Loader2"]')).toBeTruthy();
@@ -533,9 +528,7 @@ describe('WeatherModal', () => {
 
 describe('AlertModals', () => {
   async function importComponent() {
-    const { AlertModals } = await import(
-      '../src/modules/anchor/components/modals/AlertModals'
-    );
+    const { AlertModals } = await import('../src/modules/anchor/components/modals/AlertModals');
     return AlertModals;
   }
 
@@ -581,11 +574,7 @@ describe('AlertModals', () => {
     const AlertModals = await importComponent();
     const { container } = render(
       <Wrapper>
-        <AlertModals
-          {...allClosed}
-          watchAlertOpen={true}
-          onWatchAlertOk={onWatchAlertOk}
-        />
+        <AlertModals {...allClosed} watchAlertOpen={true} onWatchAlertOk={onWatchAlertOk} />
       </Wrapper>,
     );
     const okBtn = container.querySelector('#watch-alert-ok-btn')!;
@@ -599,9 +588,7 @@ describe('AlertModals', () => {
 
 describe('OffsetModal', () => {
   async function importComponent() {
-    const { OffsetModal } = await import(
-      '../src/modules/anchor/components/modals/OffsetModal'
-    );
+    const { OffsetModal } = await import('../src/modules/anchor/components/modals/OffsetModal');
     return OffsetModal;
   }
 
@@ -615,7 +602,9 @@ describe('OffsetModal', () => {
   it('renders distance and bearing inputs', async () => {
     const OffsetModal = await importComponent();
     const { container } = render(
-      <Wrapper><OffsetModal {...defaultProps} /></Wrapper>,
+      <Wrapper>
+        <OffsetModal {...defaultProps} />
+      </Wrapper>,
     );
     expect(container.querySelector('#offset-dist')).toBeTruthy();
     expect(container.querySelector('#offset-bearing')).toBeTruthy();
@@ -643,15 +632,32 @@ describe('OffsetModal', () => {
     expect(onApply).toHaveBeenCalledWith(50, 180);
     expect(onClose).toHaveBeenCalled();
   });
+
+  it('sets the reciprocal bearing from COG and falls back to south without COG', async () => {
+    const OffsetModal = await importComponent();
+    const { container, rerender } = render(
+      <Wrapper>
+        <OffsetModal {...defaultProps} cog={270} />
+      </Wrapper>,
+    );
+    fireEvent.click(container.querySelector('#set-bearing-behind-btn')!);
+    expect((container.querySelector('#offset-bearing') as HTMLInputElement).value).toBe('90');
+
+    rerender(
+      <Wrapper>
+        <OffsetModal {...defaultProps} cog={null} />
+      </Wrapper>,
+    );
+    fireEvent.click(container.querySelector('#set-bearing-behind-btn')!);
+    expect((container.querySelector('#offset-bearing') as HTMLInputElement).value).toBe('180');
+  });
 });
 
 // ── SectorModal ─────────────────────────────────────────────────────
 
 describe('SectorModal', () => {
   async function importComponent() {
-    const { SectorModal } = await import(
-      '../src/modules/anchor/components/modals/SectorModal'
-    );
+    const { SectorModal } = await import('../src/modules/anchor/components/modals/SectorModal');
     return SectorModal;
   }
 
@@ -667,7 +673,9 @@ describe('SectorModal', () => {
   it('renders bearing and width inputs', async () => {
     const SectorModal = await importComponent();
     const { container } = render(
-      <Wrapper><SectorModal {...defaultProps} /></Wrapper>,
+      <Wrapper>
+        <SectorModal {...defaultProps} />
+      </Wrapper>,
     );
     expect(container.querySelector('#sector-bearing')).toBeTruthy();
     expect(container.querySelector('#sector-width')).toBeTruthy();
@@ -699,9 +707,7 @@ describe('SectorModal', () => {
 
 describe('AIModal', () => {
   async function importComponent() {
-    const { AIModal } = await import(
-      '../src/modules/anchor/components/modals/AIModal'
-    );
+    const { AIModal } = await import('../src/modules/anchor/components/modals/AIModal');
     return AIModal;
   }
 
@@ -721,7 +727,9 @@ describe('AIModal', () => {
   it('renders send button and chat area', async () => {
     const AIModal = await importComponent();
     const { container } = render(
-      <Wrapper><AIModal {...defaultProps} /></Wrapper>,
+      <Wrapper>
+        <AIModal {...defaultProps} />
+      </Wrapper>,
     );
     expect(container.querySelector('#ai-chat-area')).toBeTruthy();
     expect(container.querySelector('[data-icon="Send"]')).toBeTruthy();
@@ -730,7 +738,9 @@ describe('AIModal', () => {
   it('shows loading state while generating', async () => {
     const AIModal = await importComponent();
     const { container } = render(
-      <Wrapper><AIModal {...defaultProps} loading={true} /></Wrapper>,
+      <Wrapper>
+        <AIModal {...defaultProps} loading={true} />
+      </Wrapper>,
     );
     expect(container.querySelector('[data-icon="Loader2"]')).toBeTruthy();
   });
@@ -739,7 +749,9 @@ describe('AIModal', () => {
     const AIModal = await importComponent();
     const onSendMessage = vi.fn();
     const { container } = render(
-      <Wrapper><AIModal {...defaultProps} onSendMessage={onSendMessage} /></Wrapper>,
+      <Wrapper>
+        <AIModal {...defaultProps} onSendMessage={onSendMessage} />
+      </Wrapper>,
     );
     const input = container.querySelector('input[type="text"]')!;
     const send = container.querySelector('[data-icon="Send"]')!.closest('button')!;
@@ -774,12 +786,18 @@ describe('AIModal', () => {
       onOpenApiKeyModal: vi.fn(),
       onSaveLogbook: vi.fn(),
     };
-    const { container } = render(<Wrapper><AIModal {...props} /></Wrapper>);
+    const { container } = render(
+      <Wrapper>
+        <AIModal {...props} />
+      </Wrapper>,
+    );
     fireEvent.click(container.querySelector('#ai-clear-chat-btn')!);
     fireEvent.click(container.querySelector('#edit-api-key-btn')!);
-    fireEvent.click(Array.from(container.querySelectorAll('button')).find((button) =>
-      button.textContent?.includes('Zapisz'),
-    )!);
+    fireEvent.click(
+      Array.from(container.querySelectorAll('button')).find((button) =>
+        button.textContent?.includes('Zapisz'),
+      )!,
+    );
     expect(props.onClearChat).toHaveBeenCalledOnce();
     expect(props.onOpenApiKeyModal).toHaveBeenCalledOnce();
     expect(props.onSaveLogbook).toHaveBeenCalledOnce();
@@ -792,11 +810,7 @@ describe('AIModal', () => {
     const onOpenApiKeyModal = vi.fn();
     const { container } = render(
       <Wrapper>
-        <AIModal
-          {...defaultProps}
-          hasApiKey={false}
-          onOpenApiKeyModal={onOpenApiKeyModal}
-        />
+        <AIModal {...defaultProps} hasApiKey={false} onOpenApiKeyModal={onOpenApiKeyModal} />
       </Wrapper>,
     );
     const input = container.querySelector('input[type="text"]') as HTMLInputElement;
@@ -813,9 +827,7 @@ describe('AIModal', () => {
 
 describe('ApiKeyModal', () => {
   async function importComponent() {
-    const { ApiKeyModal } = await import(
-      '../src/modules/anchor/components/modals/ApiKeyModal'
-    );
+    const { ApiKeyModal } = await import('../src/modules/anchor/components/modals/ApiKeyModal');
     return ApiKeyModal;
   }
 
@@ -830,7 +842,9 @@ describe('ApiKeyModal', () => {
   it('renders API key input', async () => {
     const ApiKeyModal = await importComponent();
     const { container } = render(
-      <Wrapper><ApiKeyModal {...defaultProps} /></Wrapper>,
+      <Wrapper>
+        <ApiKeyModal {...defaultProps} />
+      </Wrapper>,
     );
     const input = container.querySelector('#api-key-input') as HTMLInputElement;
     expect(input).toBeTruthy();
@@ -875,9 +889,11 @@ describe('ApiKeyModal', () => {
     fireEvent.click(container.querySelector('#save-api-key-btn')!);
     expect(onSave).not.toHaveBeenCalled();
     fireEvent.click(container.querySelector('#delete-api-key-btn')!);
-    fireEvent.click(Array.from(container.querySelectorAll('button')).find((button) =>
-      button.textContent?.match(/Anuluj|Cancel/),
-    )!);
+    fireEvent.click(
+      Array.from(container.querySelectorAll('button')).find((button) =>
+        button.textContent?.match(/Anuluj|Cancel/),
+      )!,
+    );
     expect(onClear).toHaveBeenCalledOnce();
     expect(onClose).toHaveBeenCalledOnce();
   });
@@ -887,9 +903,7 @@ describe('ApiKeyModal', () => {
 
 describe('QRScanModal', () => {
   async function importComponent() {
-    const { QRScanModal } = await import(
-      '../src/modules/anchor/components/modals/QRScanModal'
-    );
+    const { QRScanModal } = await import('../src/modules/anchor/components/modals/QRScanModal');
     return QRScanModal;
   }
 

--- a/pwa/tests/anchor-modals.test.tsx
+++ b/pwa/tests/anchor-modals.test.tsx
@@ -511,6 +511,22 @@ describe('WeatherModal', () => {
     // Loading spinner icon should be present
     expect(container.querySelector('[data-icon="Loader2"]')).toBeTruthy();
   });
+
+  it('renders forecast charts and missing-value placeholders', async () => {
+    const WeatherModal = await importComponent();
+    const { container } = render(
+      <Wrapper>
+        <WeatherModal
+          {...defaultProps}
+          windForecast={[4, 8, 12]}
+          gustForecast={[6, 10, 14]}
+          waveForecast={[0.4, 0.8, 1.2]}
+        />
+      </Wrapper>,
+    );
+    expect(container.querySelectorAll('svg rect.weather-bar').length).toBe(9);
+    expect(container.textContent).toContain('--');
+  });
 });
 
 // ── AlertModals ─────────────────────────────────────────────────────
@@ -718,6 +734,79 @@ describe('AIModal', () => {
     );
     expect(container.querySelector('[data-icon="Loader2"]')).toBeTruthy();
   });
+
+  it('sends trimmed messages by button and Enter but ignores invalid sends', async () => {
+    const AIModal = await importComponent();
+    const onSendMessage = vi.fn();
+    const { container } = render(
+      <Wrapper><AIModal {...defaultProps} onSendMessage={onSendMessage} /></Wrapper>,
+    );
+    const input = container.querySelector('input[type="text"]')!;
+    const send = container.querySelector('[data-icon="Send"]')!.closest('button')!;
+
+    fireEvent.change(input, { target: { value: '  status kotwicy  ' } });
+    fireEvent.click(send);
+    expect(onSendMessage).toHaveBeenCalledWith('status kotwicy');
+
+    fireEvent.change(input, { target: { value: 'kolejne pytanie' } });
+    fireEvent.keyDown(input, { key: 'Enter', shiftKey: false });
+    expect(onSendMessage).toHaveBeenCalledWith('kolejne pytanie');
+
+    fireEvent.change(input, { target: { value: '   ' } });
+    fireEvent.keyDown(input, { key: 'Enter', shiftKey: true });
+    expect(onSendMessage).toHaveBeenCalledTimes(2);
+  });
+
+  it('runs chat, API-key, and logbook actions and renders both message roles', async () => {
+    const AIModal = await importComponent();
+    const props = {
+      ...defaultProps,
+      chatMessages: [
+        { role: 'user' as const, content: 'Pytanie' },
+        { role: 'assistant' as const, content: 'Odpowiedź' },
+      ],
+      logbookEntry: {
+        summary: 'Podsumowanie',
+        logEntry: 'Wpis dziennika',
+        safetyNote: 'Uwaga bezpieczeństwa',
+      },
+      onClearChat: vi.fn(),
+      onOpenApiKeyModal: vi.fn(),
+      onSaveLogbook: vi.fn(),
+    };
+    const { container } = render(<Wrapper><AIModal {...props} /></Wrapper>);
+    fireEvent.click(container.querySelector('#ai-clear-chat-btn')!);
+    fireEvent.click(container.querySelector('#edit-api-key-btn')!);
+    fireEvent.click(Array.from(container.querySelectorAll('button')).find((button) =>
+      button.textContent?.includes('Zapisz'),
+    )!);
+    expect(props.onClearChat).toHaveBeenCalledOnce();
+    expect(props.onOpenApiKeyModal).toHaveBeenCalledOnce();
+    expect(props.onSaveLogbook).toHaveBeenCalledOnce();
+    expect(container.textContent).toContain('Pytanie');
+    expect(container.textContent).toContain('Odpowiedź');
+  });
+
+  it('offers API-key setup when no key is configured', async () => {
+    const AIModal = await importComponent();
+    const onOpenApiKeyModal = vi.fn();
+    const { container } = render(
+      <Wrapper>
+        <AIModal
+          {...defaultProps}
+          hasApiKey={false}
+          onOpenApiKeyModal={onOpenApiKeyModal}
+        />
+      </Wrapper>,
+    );
+    const input = container.querySelector('input[type="text"]') as HTMLInputElement;
+    expect(input.disabled).toBe(true);
+    const setup = Array.from(container.querySelectorAll('button')).find((button) =>
+      button.className.includes('underline'),
+    );
+    fireEvent.click(setup!);
+    expect(onOpenApiKeyModal).toHaveBeenCalledOnce();
+  });
 });
 
 // ── ApiKeyModal ─────────────────────────────────────────────────────
@@ -765,6 +854,32 @@ describe('ApiKeyModal', () => {
 
     expect(onSave).toHaveBeenCalledWith('AIzaSyTest123');
     expect(onClose).toHaveBeenCalled();
+  });
+
+  it('keeps an empty key unsaved and clears an existing key', async () => {
+    const ApiKeyModal = await importComponent();
+    const onSave = vi.fn();
+    const onClear = vi.fn();
+    const onClose = vi.fn();
+    const { container } = render(
+      <Wrapper>
+        <ApiKeyModal
+          {...defaultProps}
+          hasKey={true}
+          onSave={onSave}
+          onClear={onClear}
+          onClose={onClose}
+        />
+      </Wrapper>,
+    );
+    fireEvent.click(container.querySelector('#save-api-key-btn')!);
+    expect(onSave).not.toHaveBeenCalled();
+    fireEvent.click(container.querySelector('#delete-api-key-btn')!);
+    fireEvent.click(Array.from(container.querySelectorAll('button')).find((button) =>
+      button.textContent?.match(/Anuluj|Cancel/),
+    )!);
+    expect(onClear).toHaveBeenCalledOnce();
+    expect(onClose).toHaveBeenCalledOnce();
   });
 });
 

--- a/pwa/tests/dashboard-ui.test.ts
+++ b/pwa/tests/dashboard-ui.test.ts
@@ -328,6 +328,18 @@ describe('dashboard-ui', () => {
       // Should not throw
     });
 
+    it('prompts for installation and consumes the deferred event', async () => {
+      const prompt = vi.fn().mockResolvedValue(undefined);
+      const event = new Event('beforeinstallprompt') as any;
+      event.prompt = prompt;
+      event.userChoice = Promise.resolve({ outcome: 'accepted' });
+      window.dispatchEvent(event);
+      document.getElementById('installBtn')!.click();
+      await event.userChoice;
+      expect(prompt).toHaveBeenCalledOnce();
+      expect(document.getElementById('installBanner')!.classList.contains('show')).toBe(false);
+    });
+
     it('dismiss button hides banner and sets sessionStorage', () => {
       document.getElementById('installBanner')!.classList.add('show');
       document.getElementById('installDismissBtn')!.click();
@@ -426,6 +438,13 @@ describe('dashboard-ui', () => {
       initDashboard();
       // controllerchange handler was registered
       expect(addEventListenerSpy).toHaveBeenCalledWith('controllerchange', expect.any(Function));
+      const handler = addEventListenerSpy.mock.calls.find(
+        ([event]) => event === 'controllerchange',
+      )![1];
+      expect(() => {
+        handler();
+        handler();
+      }).not.toThrow();
     });
 
     it('updateBtn posts SKIP_WAITING when newWorker is set', () => {
@@ -439,6 +458,78 @@ describe('dashboard-ui', () => {
       initDashboard();
       // Without newWorker set, click falls through to else
       document.getElementById('updateBtn')!.click();
+    });
+
+    it('shows an update waiting at registration and activates it', async () => {
+      document.body.innerHTML = `
+        <button id="forceUpdateBtn"></button>
+        <div id="installBanner"></div>
+        <div id="updateBanner"></div>
+        <button id="updateBtn"></button>
+        <button id="dismissBtn"></button>
+      `;
+      const waiting = { postMessage: vi.fn() };
+      Object.defineProperty(navigator, 'serviceWorker', {
+        value: {
+          addEventListener: vi.fn(),
+          register: vi.fn().mockResolvedValue({
+            waiting,
+            installing: null,
+            addEventListener: vi.fn(),
+            update: vi.fn(),
+          }),
+          controller: {},
+        },
+        configurable: true,
+      });
+      initDashboard();
+      window.dispatchEvent(new Event('load'));
+      await vi.waitFor(() =>
+        expect(document.getElementById('updateBanner')!.classList.contains('show')).toBe(true),
+      );
+      document.getElementById('updateBtn')!.click();
+      expect(waiting.postMessage).toHaveBeenCalledWith({ type: 'SKIP_WAITING' });
+    });
+
+    it('shows the update banner when an installing worker becomes installed', async () => {
+      document.body.innerHTML = `
+        <button id="forceUpdateBtn"></button>
+        <div id="installBanner"></div>
+        <div id="updateBanner"></div>
+        <button id="updateBtn"></button>
+        <button id="dismissBtn"></button>
+      `;
+      let updateFound!: () => void;
+      let stateChange!: () => void;
+      const installing = {
+        state: 'installing',
+        addEventListener: vi.fn((_event: string, handler: () => void) => {
+          stateChange = handler;
+        }),
+      };
+      const registration = {
+        waiting: null,
+        installing,
+        update: vi.fn(),
+        addEventListener: vi.fn((_event: string, handler: () => void) => {
+          updateFound = handler;
+        }),
+      };
+      Object.defineProperty(navigator, 'serviceWorker', {
+        value: {
+          addEventListener: vi.fn(),
+          register: vi.fn().mockResolvedValue(registration),
+          controller: {},
+        },
+        configurable: true,
+      });
+      initDashboard();
+      window.dispatchEvent(new Event('load'));
+      await vi.waitFor(() => expect(updateFound).toEqual(expect.any(Function)));
+      updateFound();
+      installing.state = 'installed';
+      stateChange();
+      expect(document.getElementById('updateBanner')!.classList.contains('show')).toBe(true);
     });
 
     it('dismissBtn hides update banner', () => {

--- a/pwa/tests/egzamin-app-orchestration.test.tsx
+++ b/pwa/tests/egzamin-app-orchestration.test.tsx
@@ -1,0 +1,195 @@
+import React from 'react';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { EgzaminQuestion } from '../src/modules/egzamin/types';
+
+const runtime = vi.hoisted(() => ({
+  initialize: vi.fn(),
+  clear: vi.fn(),
+  saveProgress: vi.fn(),
+  saveLeitner: vi.fn(),
+}));
+
+vi.mock('../src/modules/egzamin/pdf-runtime', () => ({
+  initializeEgzaminPdf: runtime.initialize,
+  clearEgzaminPdf: runtime.clear,
+}));
+
+vi.mock('../src/modules/egzamin/exam-storage', () => ({
+  loadProgress: () => ({ answered: {}, stats: { correct: 0, incorrect: 0, total: 0 } }),
+  saveProgress: runtime.saveProgress,
+  loadLeitnerState: () => ({ boxes: { q1: 1 }, lastReview: {} }),
+  saveLeitnerState: runtime.saveLeitner,
+}));
+
+vi.mock('../src/modules/egzamin/helpers', () => ({
+  getDueQuestions: (_state: unknown, questions: EgzaminQuestion[]) => questions,
+}));
+
+vi.mock('../src/modules/egzamin/components/ImportPdfScreen', () => ({
+  ImportPdfScreen: ({ onImportComplete }: { onImportComplete: () => void }) => (
+    <button onClick={onImportComplete}>complete-import</button>
+  ),
+}));
+
+vi.mock('../src/modules/egzamin/components/MenuScreen', () => ({
+  MenuScreen: (props: Record<string, () => void>) => (
+    <div>
+      <span>menu-screen</span>
+      <button onClick={props.onStartLearn}>start-learn</button>
+      <button onClick={props.onStartExam}>start-exam</button>
+      <button onClick={props.onStartLeitner}>start-leitner</button>
+      <button onClick={props.onChangePdf}>change-pdf</button>
+    </div>
+  ),
+}));
+
+vi.mock('../src/modules/egzamin/components/LearnScreen', () => ({
+  LearnScreen: (props: Record<string, (...args: unknown[]) => void>) => (
+    <div>
+      <span>learn-screen</span>
+      <button
+        onClick={() =>
+          props.onUpdateProgress({
+            answered: { q1: { answer: 'A', correct: true, timestamp: 1 } },
+            stats: { correct: 1, incorrect: 0, total: 1 },
+          })
+        }
+      >
+        update-progress
+      </button>
+      <button onClick={() => props.onBack()}>learn-back</button>
+    </div>
+  ),
+}));
+
+vi.mock('../src/modules/egzamin/components/ExamScreen', () => ({
+  ExamScreen: (props: Record<string, (...args: unknown[]) => void>) => (
+    <div>
+      <span>exam-screen</span>
+      <button onClick={() => props.onFinish([{ questionId: 'q1', answer: 'A' }], 42)}>
+        finish-exam
+      </button>
+      <button onClick={() => props.onBack()}>exam-back</button>
+    </div>
+  ),
+}));
+
+vi.mock('../src/modules/egzamin/components/ResultsScreen', () => ({
+  ResultsScreen: (props: Record<string, () => void>) => (
+    <div>
+      <span>results-screen</span>
+      <button onClick={props.onRetry}>retry-exam</button>
+      <button onClick={props.onBack}>results-back</button>
+    </div>
+  ),
+}));
+
+vi.mock('../src/modules/egzamin/components/LeitnerOverviewScreen', () => ({
+  LeitnerOverviewScreen: (props: Record<string, () => void>) => (
+    <div>
+      <span>leitner-overview</span>
+      <button onClick={props.onStartSession}>start-session</button>
+      <button onClick={props.onReset}>reset-leitner</button>
+      <button onClick={props.onBack}>overview-back</button>
+    </div>
+  ),
+}));
+
+vi.mock('../src/modules/egzamin/components/LeitnerSessionScreen', () => ({
+  LeitnerSessionScreen: (props: Record<string, (...args: unknown[]) => void>) => (
+    <div>
+      <span>leitner-session</span>
+      <button onClick={() => props.onUpdateLeitner({ boxes: { q1: 2 }, lastReview: {} })}>
+        update-leitner
+      </button>
+      <button onClick={() => props.onComplete(3, 1, { boxes: { q1: 3 }, lastReview: { q1: 1 } })}>
+        complete-leitner
+      </button>
+      <button onClick={() => props.onBack()}>session-back</button>
+    </div>
+  ),
+}));
+
+vi.mock('../src/modules/egzamin/components/LeitnerCompleteScreen', () => ({
+  LeitnerCompleteScreen: (props: Record<string, () => void>) => (
+    <div>
+      <span>leitner-complete</span>
+      <button onClick={props.onBack}>complete-back</button>
+    </div>
+  ),
+}));
+
+const question: EgzaminQuestion = {
+  id: 'q1',
+  category: 'nawigacja',
+  correctAnswer: 'A',
+  answerCount: 4,
+  pdfPage: 1,
+  cropYStart: 0,
+  cropYEnd: 100,
+  pageHeight: 800,
+};
+
+describe('Egzamin App orchestration', () => {
+  beforeEach(() => {
+    runtime.initialize.mockReset();
+    runtime.clear.mockReset().mockResolvedValue(undefined);
+    runtime.saveProgress.mockReset();
+    runtime.saveLeitner.mockReset();
+  });
+
+  afterEach(cleanup);
+
+  it('handles PDF initialization failure, import completion, and PDF replacement', async () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    runtime.initialize.mockRejectedValueOnce(new Error('broken PDF'));
+    const { App } = await import('../src/modules/egzamin/App');
+    render(<App questions={[question]} />);
+
+    await waitFor(() => expect(screen.getByText('complete-import')).toBeTruthy());
+    fireEvent.click(screen.getByText('complete-import'));
+    expect(screen.getByText('menu-screen')).toBeTruthy();
+
+    fireEvent.click(screen.getByText('change-pdf'));
+    await waitFor(() => expect(screen.getByText('complete-import')).toBeTruthy());
+    expect(runtime.clear).toHaveBeenCalledOnce();
+    consoleSpy.mockRestore();
+  });
+
+  it('drives learn, exam, results, and every Leitner mode', async () => {
+    runtime.initialize.mockResolvedValue(true);
+    const { App } = await import('../src/modules/egzamin/App');
+    render(<App questions={[question]} />);
+    await waitFor(() => expect(screen.getByText('menu-screen')).toBeTruthy());
+
+    fireEvent.click(screen.getByText('start-learn'));
+    fireEvent.click(screen.getByText('update-progress'));
+    expect(runtime.saveProgress).toHaveBeenCalledOnce();
+    fireEvent.click(screen.getByText('learn-back'));
+
+    fireEvent.click(screen.getByText('start-exam'));
+    fireEvent.click(screen.getByText('exam-back'));
+    fireEvent.click(screen.getByText('start-exam'));
+    fireEvent.click(screen.getByText('finish-exam'));
+    expect(screen.getByText('results-screen')).toBeTruthy();
+    fireEvent.click(screen.getByText('retry-exam'));
+    expect(screen.getByText('exam-screen')).toBeTruthy();
+    fireEvent.click(screen.getByText('finish-exam'));
+    fireEvent.click(screen.getByText('results-back'));
+
+    fireEvent.click(screen.getByText('start-leitner'));
+    fireEvent.click(screen.getByText('reset-leitner'));
+    fireEvent.click(screen.getByText('start-session'));
+    fireEvent.click(screen.getByText('update-leitner'));
+    fireEvent.click(screen.getByText('session-back'));
+    fireEvent.click(screen.getByText('start-session'));
+    fireEvent.click(screen.getByText('complete-leitner'));
+    expect(screen.getByText('leitner-complete')).toBeTruthy();
+    fireEvent.click(screen.getByText('complete-back'));
+    fireEvent.click(screen.getByText('overview-back'));
+
+    expect(screen.getByText('menu-screen')).toBeTruthy();
+    expect(runtime.saveLeitner).toHaveBeenCalledTimes(3);
+  });
+});

--- a/pwa/tests/egzamin-components.test.tsx
+++ b/pwa/tests/egzamin-components.test.tsx
@@ -105,6 +105,34 @@ describe('egzamin/components — ProgressBar', () => {
     const bar = container.querySelector('[style]');
     if (bar?.parentElement) fireEvent.click(bar.parentElement);
   });
+
+  it('clamps navigation clicks and handles zero totals and no callback', async () => {
+    const { ProgressBar } = await import('../src/modules/egzamin/components/ProgressBar');
+    const onNavigate = vi.fn();
+    const { container, rerender } = render(
+      <ProgressBar current={0} total={5} correct={0} incorrect={0} onNavigate={onNavigate} />,
+    );
+    const track = container.querySelector('.progress-fill')!.parentElement!;
+    vi.spyOn(track, 'getBoundingClientRect').mockReturnValue({
+      left: 100,
+      width: 200,
+      top: 0,
+      right: 300,
+      bottom: 10,
+      height: 10,
+      x: 100,
+      y: 0,
+      toJSON: () => ({}),
+    });
+    fireEvent.click(track, { clientX: 0 });
+    fireEvent.click(track, { clientX: 500 });
+    expect(onNavigate).toHaveBeenNthCalledWith(1, 0);
+    expect(onNavigate).toHaveBeenNthCalledWith(2, 4);
+
+    rerender(<ProgressBar current={0} total={0} correct={0} incorrect={0} />);
+    fireEvent.click(container.querySelector('.progress-fill')!.parentElement!);
+    expect((container.querySelector('.progress-fill') as HTMLElement).style.width).toBe('0%');
+  });
 });
 
 describe('egzamin/components — CategoryBadge', () => {
@@ -274,6 +302,78 @@ describe('egzamin/components — MenuScreen', () => {
       expect(onStartLearn).toHaveBeenCalled();
     }
   });
+
+  it('runs exam, Leitner, PDF-change, and reset confirmation paths', async () => {
+    const { MenuScreen } = await import('../src/modules/egzamin/components/MenuScreen');
+    const { saveProgress } = await import('../src/modules/egzamin/exam-storage');
+    const onStartExam = vi.fn();
+    const onStartLeitner = vi.fn();
+    const onChangePdf = vi.fn();
+    const confirmSpy = vi.fn();
+    Object.defineProperty(window, 'confirm', { value: confirmSpy, configurable: true });
+    const progress = {
+      answered: { q1: { correct: true } },
+      stats: { correct: 1, incorrect: 0, total: 1 },
+    };
+    render(
+      <MenuScreen
+        questions={[makeQuestion()]}
+        progress={progress}
+        leitnerState={emptyLeitner}
+        onStartLearn={vi.fn()}
+        onStartExam={onStartExam}
+        onStartLeitner={onStartLeitner}
+        onChangePdf={onChangePdf}
+      />,
+    );
+
+    fireEvent.click(screen.getByText('Egzamin').closest('button')!);
+    fireEvent.click(screen.getByText('Leitner').closest('button')!);
+    expect(onStartExam).toHaveBeenCalledOnce();
+    expect(onStartLeitner).toHaveBeenCalledOnce();
+
+    confirmSpy.mockReturnValueOnce(false);
+    fireEvent.click(screen.getByText('Resetuj postęp'));
+    expect(saveProgress).not.toHaveBeenCalled();
+    confirmSpy.mockReturnValueOnce(true);
+    fireEvent.click(screen.getByText('Resetuj postęp'));
+    expect(saveProgress).toHaveBeenCalled();
+
+    confirmSpy.mockReturnValueOnce(false);
+    fireEvent.click(screen.getByText('Zmień bazę pytań (PDF)'));
+    expect(onChangePdf).not.toHaveBeenCalled();
+    confirmSpy.mockReturnValueOnce(true);
+    fireEvent.click(screen.getByText('Zmień bazę pytań (PDF)'));
+    expect(onChangePdf).toHaveBeenCalledOnce();
+  });
+
+  it('handles an empty question set and repeated categories', async () => {
+    const { MenuScreen } = await import('../src/modules/egzamin/components/MenuScreen');
+    const { container, rerender } = render(
+      <MenuScreen
+        questions={[]}
+        progress={emptyProgress}
+        leitnerState={emptyLeitner}
+        onStartLearn={vi.fn()}
+        onStartExam={vi.fn()}
+        onStartLeitner={vi.fn()}
+        onChangePdf={vi.fn()}
+      />,
+    );
+    expect(container.textContent).toContain('0%');
+    rerender(
+      <MenuScreen
+        questions={[makeQuestion(), makeQuestion({ id: 'q2' })]}
+        progress={emptyProgress}
+        leitnerState={emptyLeitner}
+        onStartLearn={vi.fn()}
+        onStartExam={vi.fn()}
+        onStartLeitner={vi.fn()}
+        onChangePdf={vi.fn()}
+      />,
+    );
+    expect(container.textContent).toContain('2 pytań');
+  });
 });
 
 describe('egzamin/components — ExamScreen', () => {
@@ -350,6 +450,34 @@ describe('egzamin/components — ResultsScreen', () => {
       fireEvent.click(retryBtn);
       expect(onRetry).toHaveBeenCalled();
     }
+  });
+
+  it('renders passed mixed-category details and runs all result actions', async () => {
+    const { ResultsScreen } = await import('../src/modules/egzamin/components/ResultsScreen');
+    const onBack = vi.fn();
+    const onRetry = vi.fn();
+    const results: ExamResult[] = [
+      { question: makeQuestion({ id: 'q1', category: 'nawigacja' }), userAnswer: 'A', correct: true },
+      { question: makeQuestion({ id: 'q2', category: 'nawigacja' }), userAnswer: '', correct: false },
+      { question: makeQuestion({ id: 'q3', category: 'locja' }), userAnswer: 'A', correct: true },
+      { question: makeQuestion({ id: 'q4', category: 'locja' }), userAnswer: 'A', correct: true },
+    ];
+    const { container } = render(
+      <ResultsScreen results={results} timeTaken={125} onBack={onBack} onRetry={onRetry} />,
+    );
+    expect(container.textContent).toContain('Egzamin zdany!');
+    expect(container.textContent).toContain('2:05');
+
+    fireEvent.click(screen.getByText('Pokaż szczegóły pytań'));
+    expect(container.textContent).toContain('brak');
+    expect(container.textContent).toContain('OK');
+    expect(container.textContent).toContain('ERR');
+    fireEvent.click(screen.getByText('Ukryj szczegóły'));
+
+    fireEvent.click(screen.getByText('Spróbuj ponownie'));
+    fireEvent.click(screen.getByText('Powrót do menu'));
+    expect(onRetry).toHaveBeenCalledOnce();
+    expect(onBack).toHaveBeenCalledOnce();
   });
 });
 

--- a/pwa/tests/entry-bootstrap.test.ts
+++ b/pwa/tests/entry-bootstrap.test.ts
@@ -6,8 +6,14 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 // ── main.ts deps ─────────────────────────────────────────────────────────
 const mockInitDashboard = vi.fn();
+const mockInitRouter = vi.fn();
+const mockNavigateToModule = vi.fn();
 vi.mock('../src/modules/dashboard/dashboard-ui', () => ({
   initDashboard: mockInitDashboard,
+}));
+vi.mock('../src/router', () => ({
+  initRouter: mockInitRouter,
+  navigateToModule: mockNavigateToModule,
 }));
 
 // ── anchor/entry deps (React) ────────────────────────────────────────────
@@ -29,7 +35,7 @@ vi.mock('leaflet', () => ({
 }));
 
 // ── egzamin/entry deps ──────────────────────────────────────────────────
-const mockCreateRoot = vi.fn(() => ({ render: vi.fn() }));
+const mockCreateRoot = vi.fn(() => ({ render: vi.fn(), unmount: vi.fn() }));
 vi.mock('react-dom/client', () => ({
   createRoot: mockCreateRoot,
 }));
@@ -68,11 +74,48 @@ describe('main.ts entry', () => {
   beforeEach(() => {
     vi.resetModules();
     mockInitDashboard.mockClear();
+    mockInitRouter.mockClear();
+    document.body.innerHTML = '';
   });
 
   it('calls initDashboard on import', async () => {
     await import('../src/main');
     expect(mockInitDashboard).toHaveBeenCalledOnce();
+  });
+
+  it('wires all SPA routes when the dashboard DOM is complete', async () => {
+    document.body.innerHTML = `
+      <main id="dashboard-content"></main>
+      <div id="router-outlet"></div>
+      <div id="router-loading"></div>
+    `;
+    await import('../src/main');
+    expect(mockInitRouter).toHaveBeenCalledOnce();
+    const config = mockInitRouter.mock.calls[0][0];
+    expect(config.routes.map((route: { path: string }) => route.path)).toEqual([
+      '/egzamin',
+      '/wachtownik',
+      '/zeglowanie',
+      '/anchor',
+    ]);
+    for (const route of config.routes) {
+      const module = await route.loader();
+      expect(module.mount).toEqual(expect.any(Function));
+      expect(module.unmount).toEqual(expect.any(Function));
+      const container = document.createElement('div');
+      module.mount(container);
+      module.unmount();
+    }
+  });
+
+  it.each([
+    ['router-outlet', '<div id="dashboard-content"></div><div id="router-loading"></div>'],
+    ['dashboard-content', '<div id="router-outlet"></div><div id="router-loading"></div>'],
+    ['router-loading', '<div id="router-outlet"></div><div id="dashboard-content"></div>'],
+  ])('does not initialize the router without %s', async (_missing, html) => {
+    document.body.innerHTML = html;
+    await import('../src/main');
+    expect(mockInitRouter).not.toHaveBeenCalled();
   });
 });
 

--- a/pwa/tests/router.test.ts
+++ b/pwa/tests/router.test.ts
@@ -84,6 +84,11 @@ describe('router', () => {
       window.location.hash = '#/wachtownik';
       expect(getHashPath()).toBe('/wachtownik');
     });
+
+    it('normalizes a hash without a slash', () => {
+      window.location.hash = '#anchor';
+      expect(getHashPath()).toBe('/anchor');
+    });
   });
 
   // ─── initRouter ───────────────────────────────────────────────────
@@ -154,6 +159,50 @@ describe('router', () => {
       expect(cfg.outlet.style.display).not.toBe('none');
       expect(cfg.dashboardEl.style.display).toBe('none');
       expect(cfg.outlet.querySelector('#spa-root')).toBeTruthy();
+    });
+
+    it('keeps the default title when a route has no title', async () => {
+      document.title = 'OpenAnchor';
+      const cfg = makeConfig([{ path: '/plain', loader: () => Promise.resolve(fakeModule()) }]);
+      destroy = initRouter(cfg);
+      await navigateTo('/plain');
+      expect(document.title).toBe('OpenAnchor');
+    });
+
+    it('ignores a stale module result after navigating elsewhere', async () => {
+      let resolveLoader!: (module: ModuleMount) => void;
+      const cfg = makeConfig([
+        {
+          path: '/slow',
+          loader: () => new Promise<ModuleMount>((resolve) => { resolveLoader = resolve; }),
+        },
+      ]);
+      destroy = initRouter(cfg);
+      const pending = navigateTo('/slow');
+      await navigateTo('/');
+      const mod = fakeModule();
+      resolveLoader(mod);
+      await pending;
+      expect(mod.mounted).toBe(false);
+    });
+
+    it('ignores outlet clicks that are not navigation links', async () => {
+      const cfg = makeConfig([{ path: '/plain', loader: () => Promise.resolve(fakeModule()) }]);
+      destroy = initRouter(cfg);
+      await navigateTo('/plain');
+      cfg.outlet.querySelector('p')!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      expect(window.location.hash).toBe('');
+    });
+
+    it.each(['/', '../', '../../'])('intercepts the legacy back href %s', async (href) => {
+      const cfg = makeConfig([{ path: '/plain', loader: () => Promise.resolve(fakeModule()) }]);
+      destroy = initRouter(cfg);
+      await navigateTo('/plain');
+      const link = document.createElement('a');
+      link.setAttribute('href', href);
+      cfg.outlet.querySelector('#spa-root')!.appendChild(link);
+      link.click();
+      expect(window.location.hash).toBe('#/');
     });
 
     it('unmounts the previous module on new navigation', async () => {

--- a/pwa/tests/shared-components-render.test.tsx
+++ b/pwa/tests/shared-components-render.test.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { BackButton } from '../src/shared/components/BackButton';
+import { ErrorBoundary } from '../src/shared/components/ErrorBoundary';
+
+afterEach(cleanup);
+
+describe('shared components behavior', () => {
+  it('follows the default back link when no callback is supplied', () => {
+    render(<BackButton />);
+    expect(screen.getByRole('link', { name: '← Powrót' }).getAttribute('href')).toBe('../');
+  });
+
+  it('prevents navigation and delegates custom back actions', () => {
+    const onClick = vi.fn();
+    render(<BackButton href="/menu" label="Menu" onClick={onClick} />);
+
+    const link = screen.getByRole('link', { name: 'Menu' });
+    const accepted = fireEvent.click(link);
+    expect(accepted).toBe(false);
+    expect(onClick).toHaveBeenCalledOnce();
+  });
+
+  it('renders children when no descendant throws', () => {
+    render(
+      <ErrorBoundary>
+        <div>Healthy content</div>
+      </ErrorBoundary>,
+    );
+    expect(screen.getByText('Healthy content')).toBeTruthy();
+  });
+
+  it('renders a custom fallback after an error', () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const Thrower = () => {
+      throw new Error('boom');
+    };
+
+    render(
+      <ErrorBoundary fallback={<div>Custom fallback</div>}>
+        <Thrower />
+      </ErrorBoundary>,
+    );
+    expect(screen.getByText('Custom fallback')).toBeTruthy();
+    consoleSpy.mockRestore();
+  });
+
+  it('shows the default error details and retries rendering', () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    let shouldThrow = true;
+    const ThrowOnce = () => {
+      if (shouldThrow) throw new Error('temporary failure');
+      return <div>Recovered content</div>;
+    };
+
+    render(
+      <ErrorBoundary>
+        <ThrowOnce />
+      </ErrorBoundary>,
+    );
+    expect(screen.getByText('temporary failure')).toBeTruthy();
+
+    shouldThrow = false;
+    fireEvent.click(screen.getByRole('button', { name: 'Spróbuj ponownie' }));
+    expect(screen.getByText('Recovered content')).toBeTruthy();
+    consoleSpy.mockRestore();
+  });
+});

--- a/pwa/tests/shared-i18n.test.ts
+++ b/pwa/tests/shared-i18n.test.ts
@@ -2,6 +2,9 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import { setLocale, getLocale, t, translations } from '../src/shared/i18n/index';
 
 describe('shared/i18n', () => {
+  it('falls back to the key for an unknown translation', () => {
+    expect(t('missing.translation' as any)).toBe('missing.translation');
+  });
   beforeEach(() => {
     // Reset to default locale
     setLocale('pl');

--- a/pwa/tests/ship-lights-viewer.test.tsx
+++ b/pwa/tests/ship-lights-viewer.test.tsx
@@ -1,0 +1,137 @@
+import React from 'react';
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { shipLightProfiles } from '../src/modules/zeglowanie/data/ship-lights-data';
+
+type FrameCallback = (state: { clock: { elapsedTime: number } }) => void;
+
+const frameCallbacks = vi.hoisted(() => [] as FrameCallback[]);
+const cameraPosition = vi.hoisted(() => ({ x: 4, z: -8 }));
+
+vi.mock('@react-three/fiber', () => ({
+  Canvas: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="three-canvas">{children}</div>
+  ),
+  useFrame: (callback: FrameCallback) => {
+    frameCallbacks.push(callback);
+  },
+  useThree: () => ({ camera: { position: cameraPosition } }),
+}));
+
+vi.mock('@react-three/drei', () => ({
+  OrbitControls: () => <div data-testid="orbit-controls" />,
+}));
+
+function hydrateThreeElementRefs() {
+  for (const mesh of document.querySelectorAll('mesh')) {
+    Object.assign(mesh, {
+      scale: { setScalar: vi.fn() },
+      material: { emissiveIntensity: 0 },
+    });
+  }
+}
+
+describe('ShipLightsViewer3D', () => {
+  beforeEach(() => {
+    frameCallbacks.length = 0;
+    cameraPosition.x = 4;
+    cameraPosition.z = -8;
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders every vessel profile in night mode and advances animated frames', async () => {
+    const { default: ShipLightsViewer3D } =
+      await import('../src/modules/zeglowanie/components/knowledge/ship-lights/ShipLightsViewer3D');
+    const { rerender } = render(<ShipLightsViewer3D profile={shipLightProfiles[0]} isNight />);
+
+    for (const profile of shipLightProfiles) {
+      const firstNewCallback = frameCallbacks.length;
+      rerender(<ShipLightsViewer3D profile={profile} isNight />);
+      hydrateThreeElementRefs();
+
+      await act(async () => {
+        for (const callback of frameCallbacks.slice(firstNewCallback)) {
+          callback({ clock: { elapsedTime: 1.5 } });
+          callback({ clock: { elapsedTime: 2.5 } });
+        }
+      });
+    }
+
+    expect(screen.getByTestId('three-canvas')).toBeTruthy();
+    expect(screen.getByTestId('orbit-controls')).toBeTruthy();
+    expect(screen.getByText(/Przeciągnij aby obrócić/)).toBeTruthy();
+  });
+
+  it('renders every day-mark shape and daylight hull variant', async () => {
+    const { default: ShipLightsViewer3D } =
+      await import('../src/modules/zeglowanie/components/knowledge/ship-lights/ShipLightsViewer3D');
+    const { rerender } = render(
+      <ShipLightsViewer3D profile={shipLightProfiles[0]} isNight={false} />,
+    );
+
+    for (const profile of shipLightProfiles) {
+      rerender(<ShipLightsViewer3D profile={profile} isNight={false} />);
+    }
+
+    expect(screen.getByTestId('three-canvas')).toBeTruthy();
+    expect(document.querySelectorAll('mesh').length).toBeGreaterThan(0);
+  });
+
+  it('normalizes camera bearings on both sides of north', async () => {
+    const { default: ShipLightsViewer3D } =
+      await import('../src/modules/zeglowanie/components/knowledge/ship-lights/ShipLightsViewer3D');
+    render(<ShipLightsViewer3D profile={shipLightProfiles[0]} isNight />);
+    hydrateThreeElementRefs();
+
+    await act(async () => {
+      cameraPosition.x = -4;
+      cameraPosition.z = -8;
+      for (const callback of frameCallbacks) {
+        callback({ clock: { elapsedTime: 0 } });
+      }
+    });
+
+    expect(screen.getByText('DZ')).toBeTruthy();
+    expect(screen.getByText('RU')).toBeTruthy();
+    expect(screen.getByText('Bb')).toBeTruthy();
+    expect(screen.getByText('StB')).toBeTruthy();
+  });
+
+  it('drives the complete ship-light selector in night and day modes', async () => {
+    const { default: ShipLightsSection } =
+      await import('../src/modules/zeglowanie/components/knowledge/ship-lights/ShipLightsSection');
+    const { container } = render(<ShipLightsSection />);
+
+    await waitFor(() => expect(screen.getByTestId('three-canvas')).toBeTruthy());
+    const profileButtons = Array.from(container.querySelectorAll('button')).filter((button) =>
+      shipLightProfiles.some((profile) => button.textContent?.includes(profile.name)),
+    );
+    expect(profileButtons).toHaveLength(shipLightProfiles.length);
+
+    for (const button of profileButtons) {
+      fireEvent.click(button);
+    }
+    fireEvent.click(screen.getByRole('button', { name: /Noc/ }));
+    expect(screen.getByRole('button', { name: /Dzień/ })).toBeTruthy();
+  });
+
+  it('renders VHF groups and switches knowledge topics', async () => {
+    const { default: VhfSection } =
+      await import('../src/modules/zeglowanie/components/knowledge/vhf/VhfSection');
+    const { KnowledgeSection } =
+      await import('../src/modules/zeglowanie/components/knowledge/KnowledgeSection');
+
+    const vhf = render(<VhfSection />);
+    expect(screen.getByText('Polish Rescue Radio')).toBeTruthy();
+    expect(screen.getByText('VTS Zatoka')).toBeTruthy();
+    expect(screen.getByText('Elbląg i wszystkie porty Zalewu Wiślanego')).toBeTruthy();
+    vhf.unmount();
+
+    render(<KnowledgeSection />);
+    fireEvent.click(screen.getByRole('button', { name: /VHF/ }));
+    await waitFor(() => expect(screen.getByText('Polish Rescue Radio')).toBeTruthy());
+  });
+});

--- a/pwa/tests/use-session-history.test.ts
+++ b/pwa/tests/use-session-history.test.ts
@@ -55,19 +55,17 @@ function makeSessionOps(overrides: Record<string, any> = {}) {
     db: {
       current: {
         db: {
-          getLogbookEntries: vi
-            .fn()
-            .mockResolvedValue([
-              {
-                id: 1,
-                sessionId: 1,
-                createdAt: Date.now(),
-                summary: 'test',
-                logEntry: 'log',
-                safetyNote: '',
-                isAiGenerated: false,
-              },
-            ]),
+          getLogbookEntries: vi.fn().mockResolvedValue([
+            {
+              id: 1,
+              sessionId: 1,
+              createdAt: Date.now(),
+              summary: 'test',
+              logEntry: 'log',
+              safetyNote: '',
+              isAiGenerated: false,
+            },
+          ]),
         },
       },
     },
@@ -398,6 +396,27 @@ describe('useSessionHistory', () => {
 
       rerender({ open: true });
       await waitFor(() => expect(ops.getSessionHistory).toHaveBeenCalled());
+    });
+
+    it('does not reload history when only the session wrapper identity changes', async () => {
+      const ops = makeSessionOps();
+      const { result, rerender } = renderHook(() =>
+        useSessionHistory({
+          session: { ...ops },
+          isSessionModalOpen: true,
+          isStatsModalOpen: false,
+        }),
+      );
+
+      await waitFor(() => expect(ops.getSessionHistory).toHaveBeenCalledTimes(1));
+      await act(async () => {
+        await result.current.handleReplaySession(1);
+      });
+
+      rerender();
+
+      expect(ops.getSessionHistory).toHaveBeenCalledTimes(1);
+      expect(result.current.replayData?.session.id).toBe(1);
     });
 
     it('loads stats when isStatsModalOpen becomes true', async () => {

--- a/pwa/tests/wachtownik-components.test.tsx
+++ b/pwa/tests/wachtownik-components.test.tsx
@@ -182,4 +182,96 @@ describe('wachtownik/components — ScheduleTableRow', () => {
     expect(container.textContent).toContain('Anna');
     expect(container.textContent).toContain('Piotr');
   });
+
+  it('handles editable drag and drop and marks the dragged assignment', async () => {
+    const { ScheduleTableRow } = await import('../src/modules/wachtownik/components/ScheduleTableRow');
+    const onDragStart = vi.fn();
+    const onDrop = vi.fn();
+    const onDragOver = vi.fn();
+    const { container } = render(
+      <table>
+        <tbody>
+          <ScheduleTableRow
+            daySchedule={minimalDaySchedule}
+            dayIndex={0}
+            startDate="2024-06-01"
+            isNightMode={false}
+            isReadOnly={false}
+            draggedItem={{ dayIdx: 0, slotIdx: 0, pIdx: 0 }}
+            onDragStart={onDragStart}
+            onDrop={onDrop}
+            onDragOver={onDragOver}
+            t={mockT}
+            userLocale="pl-PL"
+          />
+        </tbody>
+      </table>,
+    );
+    const assignment = container.querySelector('[draggable="true"]')!;
+    expect(assignment.className).toContain('opacity-50');
+
+    fireEvent.dragStart(assignment);
+    fireEvent.dragOver(assignment);
+    fireEvent.drop(assignment);
+
+    expect(onDragStart).toHaveBeenCalledWith(expect.anything(), 0, 0, 0);
+    expect(onDragOver).toHaveBeenCalledOnce();
+    expect(onDrop).toHaveBeenCalledWith(expect.anything(), 0, 0, 0);
+  });
+
+  it('does not run drag handlers in read-only mode', async () => {
+    const { ScheduleTableRow } = await import('../src/modules/wachtownik/components/ScheduleTableRow');
+    const onDragStart = vi.fn();
+    const onDrop = vi.fn();
+    const onDragOver = vi.fn();
+    const { container } = render(
+      <table>
+        <tbody>
+          <ScheduleTableRow
+            daySchedule={minimalDaySchedule}
+            dayIndex={0}
+            startDate="2024-06-01"
+            isNightMode={false}
+            isReadOnly={true}
+            draggedItem={null}
+            onDragStart={onDragStart}
+            onDrop={onDrop}
+            onDragOver={onDragOver}
+            t={mockT}
+            userLocale="pl-PL"
+          />
+        </tbody>
+      </table>,
+    );
+    const assignment = container.querySelector('[draggable="false"]')!;
+    fireEvent.dragStart(assignment);
+    fireEvent.dragOver(assignment);
+    fireEvent.drop(assignment);
+    expect(onDragStart).not.toHaveBeenCalled();
+    expect(onDragOver).not.toHaveBeenCalled();
+    expect(onDrop).not.toHaveBeenCalled();
+  });
+
+  it('uses the memo comparison for unchanged and changed props', async () => {
+    const { ScheduleTableRow } = await import('../src/modules/wachtownik/components/ScheduleTableRow');
+    const props = {
+      daySchedule: minimalDaySchedule,
+      dayIndex: 0,
+      startDate: '2024-06-01',
+      isNightMode: false,
+      isReadOnly: false,
+      draggedItem: null,
+      onDragStart: vi.fn(),
+      onDrop: vi.fn(),
+      onDragOver: vi.fn(),
+      t: mockT,
+      userLocale: 'pl-PL' as Locale,
+    };
+    const { rerender } = render(
+      <table><tbody><ScheduleTableRow {...props} /></tbody></table>,
+    );
+    rerender(<table><tbody><ScheduleTableRow {...props} /></tbody></table>);
+    rerender(<table><tbody><ScheduleTableRow {...props} dayIndex={1} /></tbody></table>);
+    expect(screen.getByText('label.day 1')).toBeDefined();
+  });
 });

--- a/pwa/tests/wachtownik-coverage.test.tsx
+++ b/pwa/tests/wachtownik-coverage.test.tsx
@@ -527,6 +527,43 @@ describe('SettingsBar', () => {
     expect(undo).toHaveBeenCalledOnce();
     expect(redo).toHaveBeenCalledOnce();
   });
+
+  it('runs language, sharing, file, and export actions from the menus', async () => {
+    const { SettingsBar } = await import('../src/modules/wachtownik/components/SettingsBar');
+    const props = baseProps();
+    render(<SettingsBar {...props} />);
+
+    fireEvent.click(screen.getByLabelText('Switch to English'));
+    expect(props.toggleLanguage).toHaveBeenCalledOnce();
+
+    fireEvent.click(screen.getByRole('button', { name: /Udostępnij/ }));
+    fireEvent.click(screen.getByText('QR Kod'));
+    expect(props.handleShowQR).toHaveBeenCalledOnce();
+
+    fireEvent.click(screen.getByRole('button', { name: /Udostępnij/ }));
+    fireEvent.click(screen.getByText('Link edytowalny'));
+    expect(props.handleShare).toHaveBeenCalledWith(false);
+
+    fireEvent.click(screen.getByRole('button', { name: /Udostępnij/ }));
+    fireEvent.click(screen.getByText('Link tylko do odczytu'));
+    expect(props.handleShare).toHaveBeenCalledWith(true);
+
+    fireEvent.click(screen.getByRole('button', { name: /Plik/ }));
+    fireEvent.click(screen.getByText('Eksportuj konfigurację'));
+    expect(props.handleExportConfig).toHaveBeenCalledOnce();
+
+    fireEvent.click(screen.getByRole('button', { name: /Plik/ }));
+    fireEvent.click(screen.getByText('Importuj konfigurację'));
+    expect(props.handleImportConfig).toHaveBeenCalledOnce();
+
+    fireEvent.click(screen.getByRole('button', { name: /Eksport/ }));
+    fireEvent.click(screen.getByText('Eksportuj PDF'));
+    expect(props.handleExportPDF).toHaveBeenCalledOnce();
+
+    fireEvent.click(screen.getByRole('button', { name: /Eksport/ }));
+    fireEvent.click(screen.getByText('Drukuj'));
+    expect(props.handlePrint).toHaveBeenCalledOnce();
+  });
 });
 
 // ═══════════════════════════════════════════════════════════════════════
@@ -1055,6 +1092,28 @@ describe('CrewPanel', () => {
     const input = screen.getByPlaceholderText('Imię...');
     fireEvent.change(input, { target: { value: 'Test' } });
     expect(setNewCrewName).toHaveBeenCalledWith('Test');
+  });
+
+  it('updates all crew and cruise form controls', async () => {
+    const { CrewPanel } = await import('../src/modules/wachtownik/components/CrewPanel');
+    const props = baseProps();
+    const { container } = render(<CrewPanel {...props} />);
+
+    fireEvent.change(container.querySelector('select')!, { target: { value: 'officer' } });
+    expect(props.setNewCrewRole).toHaveBeenCalledWith('officer');
+
+    fireEvent.click(container.querySelector('input[type="checkbox"]')!);
+    expect(props.setCaptainParticipates).toHaveBeenCalledWith(false);
+
+    fireEvent.change(container.querySelector('input[type="date"]')!, {
+      target: { value: '2024-07-15' },
+    });
+    expect(props.setStartDate).toHaveBeenCalledWith('2024-07-15');
+
+    fireEvent.change(container.querySelector('input[type="number"]')!, {
+      target: { value: '14' },
+    });
+    expect(props.setDays).toHaveBeenCalledWith(14);
   });
 });
 
@@ -1739,5 +1798,46 @@ describe('App', () => {
     );
     fireEvent.click(schedBtn!);
     expect(hookState.settings.setActiveTab).toHaveBeenCalledWith('schedule');
+  });
+
+  it('runs every tab callback', () => {
+    hookState.engine.isGenerated = true;
+    hookState.settings.activeTab = 'schedule';
+    const { container } = render(<App />);
+    for (const [label, tab] of [
+      ['Konfiguracja', 'setup'],
+      ['Harmonogram', 'schedule'],
+      ['Gantt', 'gantt'],
+      ['Analityka', 'analytics'],
+    ] as const) {
+      const button = Array.from(container.querySelectorAll('button')).find(
+        (candidate) =>
+          candidate.textContent?.includes(label) &&
+          !candidate.textContent?.includes('Generuj'),
+      );
+      fireEvent.click(button!);
+      expect(hookState.settings.setActiveTab).toHaveBeenCalledWith(tab);
+    }
+  });
+
+  it('runs dog-watch and template adapters from setup', () => {
+    hookState.settings.activeTab = 'setup';
+    const { container } = render(<App />);
+
+    const dogWatches = Array.from(container.querySelectorAll('button')).find((button) =>
+      button.textContent?.includes('Dodaj Psie Wachty'),
+    );
+    fireEvent.click(dogWatches!);
+    expect(hookState.watchSlots.applyDogWatches).toHaveBeenCalledWith(
+      hookState.settings.userLocale,
+      hookState.exportShare.showToast,
+    );
+
+    const template = Array.from(container.querySelectorAll('button')).find((button) =>
+      button.textContent?.includes('6 wacht × 4h'),
+    );
+    fireEvent.click(template!);
+    expect(hookState.watchSlots.applyTemplate).toHaveBeenCalled();
+    expect(hookState.engine.setIsGenerated).toHaveBeenCalledWith(false);
   });
 });

--- a/pwa/vitest.config.js
+++ b/pwa/vitest.config.js
@@ -32,10 +32,10 @@ export default defineConfig({
         'src/service-worker/sw.ts',
       ],
       thresholds: {
-        lines: 75,
-        statements: 75,
-        functions: 75,
-        branches: 75,
+        lines: 90,
+        statements: 90,
+        functions: 90,
+        branches: 90,
       },
     }
   }


### PR DESCRIPTION
## What changed

- address all four unresolved review comments from #145:
  - add the Safari-prefixed dashboard backdrop filter
  - introduce a semantic inverse Anchor tool-button modifier for the mute action
  - remove the redundant Anchor tool-button border declaration
  - remove the unused `Dashboard.isAnchored` prop
- add real browser journeys for the Anchor session lifecycle and the Żeglowanie module
- extend unit and integration coverage across Anchor, Egzamin, Wachtownik, SPA bootstrap/router, dashboard update flows, shared components, i18n, and ship-light rendering
- raise all Vitest coverage thresholds from 75% to 90% and correct the CI coverage-policy summary
- stabilize Anchor history/replay by removing test-only production markup and preventing session-wrapper rerenders from clearing replay state

## Why

PR #145 was merged before its final review comments arrived. The existing PWA test suite also left important UI callbacks, persistence flows, SPA routing, and module journeys uncovered. This follow-up keeps the visual changes consistent across Safari and Anchor controls while making the PWA unit coverage requirement materially stricter.

## Validation

- `npm run build`
- `npm run lint` — passes with pre-existing warnings only
- `npm run test:coverage -- --run` — 2023 tests passed
  - statements: 93.69%
  - branches: 90.07%
  - functions: 91.11%
  - lines: 94.52%
- Anchor persisted-session lifecycle repeated 5 times — 5/5 passed
- GPX export visibility scenario repeated 5 times — 5/5 passed
- `npm run test:e2e:coverage` — 272 tests passed on the preceding commit
  - statements: 59.21%
  - branches: 53.16%
  - functions: 63.50%
  - lines: 60.74%

## Follow-up

The E2E coverage report remains informational and is still below the planned 80% target. Android branch coverage reported by CI is also below 90%. This PR does not add or modify any coverage exclusions and does not pretend that either target has already been reached.
